### PR TITLE
[Chore] 이슈 prefix 기반 자동 레이블 워크플로우 추가

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,37 @@
+name: Auto Label Issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.issue.title;
+            const labelMap = {
+              '[Feature]': 'enhancement',
+              '[Fix]': 'bug',
+              '[Bug]': 'bug',
+              '[Docs]': 'documentation',
+              '[Chore]': 'chore',
+              '[Refactor]': 'refactor',
+              '[Test]': 'test',
+            };
+
+            for (const [prefix, label] of Object.entries(labelMap)) {
+              if (title.startsWith(prefix)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.issue.number,
+                  labels: [label]
+                });
+                break;
+              }
+            }


### PR DESCRIPTION
## 관련 Issue
없음

## 변경 사항
이슈 제목의 prefix를 감지해 자동으로 레이블을 붙이는 GitHub Actions 워크플로우 추가

| Prefix | 레이블 |
|--------|--------|
| `[Feature]` | `enhancement` |
| `[Fix]`, `[Bug]` | `bug` |
| `[Docs]` | `documentation` |
| `[Chore]` | `chore` |
| `[Refactor]` | `refactor` |
| `[Test]` | `test` |

이슈가 열리거나 제목이 수정될 때 자동으로 동작함.