### PR TITLE
feat: JWT 인증 필터 및 회원 관리 API 구현

### DIFF
--- a/src/main/java/com/capstone/interview/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/capstone/interview/config/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.capstone.interview.config;
+
+import com.capstone.interview.repository.MemberRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            String loginId = jwtProvider.getLoginId(token);
+
+            boolean exists = memberRepository.existsByLoginId(loginId);
+            if (exists) {
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(loginId, null, Collections.emptyList());
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } else {
+                log.warn("[JWT 필터] 토큰의 loginId에 해당하는 회원 없음: {}", loginId);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/capstone/interview/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/interview/config/SecurityConfig.java
@@ -1,26 +1,37 @@
 package com.capstone.interview.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()); // 모든 요청 허용. 다음 이슈에서 경로에 따라 공개여부 설정
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/v1/auth/signup", "/v1/auth/login").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/capstone/interview/controller/AuthController.java
+++ b/src/main/java/com/capstone/interview/controller/AuthController.java
@@ -2,6 +2,11 @@ package com.capstone.interview.controller;
 
 import com.capstone.interview.dto.LoginRequest;
 import com.capstone.interview.dto.LoginResponse;
+import com.capstone.interview.dto.MemberDeleteRequest;
+import com.capstone.interview.dto.MemberDeleteResponse;
+import com.capstone.interview.dto.MemberInfoResponse;
+import com.capstone.interview.dto.MemberUpdateRequest;
+import com.capstone.interview.dto.MemberUpdateResponse;
 import com.capstone.interview.dto.SignupRequest;
 import com.capstone.interview.dto.SignupResponse;
 import com.capstone.interview.service.AuthService;
@@ -9,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -34,6 +40,31 @@ public class AuthController {
 
         LoginResponse response = authService.login(request);
         log.info("[로그인 성공] loginId={}", request.loginId());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberInfoResponse> getMyInfo(Authentication authentication) {
+        String loginId = authentication.getName();
+        log.info("[내 정보 조회] loginId={}", loginId);
+        return ResponseEntity.ok(authService.getMyInfo(loginId));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<MemberUpdateResponse> updateMember(Authentication authentication,
+                                                              @RequestBody MemberUpdateRequest request) {
+        String loginId = authentication.getName();
+        log.info("[회원 정보 수정] loginId={}", loginId);
+        return ResponseEntity.ok(authService.updateMember(loginId, request));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<MemberDeleteResponse> deleteMember(Authentication authentication,
+                                                              @RequestBody MemberDeleteRequest request) {
+        String loginId = authentication.getName();
+        log.info("[회원 탈퇴 요청] loginId={}", loginId);
+        MemberDeleteResponse response = authService.deleteMember(loginId, request);
+        log.info("[회원 탈퇴 완료] loginId={}", loginId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/capstone/interview/dto/MemberDeleteRequest.java
+++ b/src/main/java/com/capstone/interview/dto/MemberDeleteRequest.java
@@ -1,0 +1,5 @@
+package com.capstone.interview.dto;
+
+public record MemberDeleteRequest(
+        String password
+) {}

--- a/src/main/java/com/capstone/interview/dto/MemberDeleteResponse.java
+++ b/src/main/java/com/capstone/interview/dto/MemberDeleteResponse.java
@@ -1,0 +1,6 @@
+package com.capstone.interview.dto;
+
+public record MemberDeleteResponse(
+        boolean success,
+        String message
+) {}

--- a/src/main/java/com/capstone/interview/dto/MemberInfoResponse.java
+++ b/src/main/java/com/capstone/interview/dto/MemberInfoResponse.java
@@ -1,0 +1,15 @@
+package com.capstone.interview.dto;
+
+import java.time.LocalDateTime;
+
+public record MemberInfoResponse(
+        boolean success,
+        Data data
+) {
+    public record Data(
+            Long id,
+            String loginId,
+            String name,
+            LocalDateTime createdAt
+    ) {}
+}

--- a/src/main/java/com/capstone/interview/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/capstone/interview/dto/MemberUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.capstone.interview.dto;
+
+public record MemberUpdateRequest(
+        String name,
+        String currentPassword,
+        String newPassword
+) {}

--- a/src/main/java/com/capstone/interview/dto/MemberUpdateResponse.java
+++ b/src/main/java/com/capstone/interview/dto/MemberUpdateResponse.java
@@ -1,0 +1,12 @@
+package com.capstone.interview.dto;
+
+public record MemberUpdateResponse(
+        boolean success,
+        Data data
+) {
+    public record Data(
+            Long id,
+            String loginId,
+            String name
+    ) {}
+}

--- a/src/main/java/com/capstone/interview/entity/Member.java
+++ b/src/main/java/com/capstone/interview/entity/Member.java
@@ -40,6 +40,14 @@ public class Member {
         this.name = name;
     }
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();

--- a/src/main/java/com/capstone/interview/repository/CoverLetterRepository.java
+++ b/src/main/java/com/capstone/interview/repository/CoverLetterRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.interview.repository;
+
+import com.capstone.interview.entity.CoverLetter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> {
+}

--- a/src/main/java/com/capstone/interview/repository/ResumeRepository.java
+++ b/src/main/java/com/capstone/interview/repository/ResumeRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.interview.repository;
+
+import com.capstone.interview.entity.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/src/main/java/com/capstone/interview/service/AuthService.java
+++ b/src/main/java/com/capstone/interview/service/AuthService.java
@@ -3,6 +3,11 @@ package com.capstone.interview.service;
 import com.capstone.interview.config.JwtProvider;
 import com.capstone.interview.dto.LoginRequest;
 import com.capstone.interview.dto.LoginResponse;
+import com.capstone.interview.dto.MemberDeleteRequest;
+import com.capstone.interview.dto.MemberDeleteResponse;
+import com.capstone.interview.dto.MemberInfoResponse;
+import com.capstone.interview.dto.MemberUpdateRequest;
+import com.capstone.interview.dto.MemberUpdateResponse;
 import com.capstone.interview.dto.SignupRequest;
 import com.capstone.interview.dto.SignupResponse;
 import com.capstone.interview.entity.Member;
@@ -73,6 +78,72 @@ public class AuthService {
                 true,
                 new LoginResponse.Data(accessToken, "Bearer", expirationMs / 1000)
         );
+    }
+
+    /**
+     * 내 정보 조회.
+     */
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMyInfo(String loginId) {
+        Member member = findMemberByLoginId(loginId);
+        return new MemberInfoResponse(
+                true,
+                new MemberInfoResponse.Data(member.getId(), member.getLoginId(), member.getName(), member.getCreatedAt())
+        );
+    }
+
+    /**
+     * 회원 정보 수정.
+     * name 변경 및 비밀번호 변경(선택) 지원.
+     * 비밀번호 변경 시 currentPassword 검증 필요.
+     */
+    @Transactional
+    public MemberUpdateResponse updateMember(String loginId, MemberUpdateRequest request) {
+        Member member = findMemberByLoginId(loginId);
+
+        if (!isBlank(request.name())) {
+            member.updateName(request.name());
+        }
+
+        if (!isBlank(request.newPassword())) {
+            if (isBlank(request.currentPassword())) {
+                throw new IllegalArgumentException("비밀번호를 변경하려면 currentPassword가 필요합니다.");
+            }
+            if (!passwordEncoder.matches(request.currentPassword(), member.getPassword())) {
+                throw new UnauthorizedException("현재 비밀번호가 올바르지 않습니다.");
+            }
+            member.updatePassword(passwordEncoder.encode(request.newPassword()));
+        }
+
+        return new MemberUpdateResponse(
+                true,
+                new MemberUpdateResponse.Data(member.getId(), member.getLoginId(), member.getName())
+        );
+    }
+
+    /**
+     * 회원 탈퇴.
+     * 비밀번호 확인 후 계정 삭제.
+     */
+    @Transactional
+    public MemberDeleteResponse deleteMember(String loginId, MemberDeleteRequest request) {
+        if (isBlank(request.password())) {
+            throw new IllegalArgumentException("password는 필수입니다.");
+        }
+
+        Member member = findMemberByLoginId(loginId);
+
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new UnauthorizedException("비밀번호가 올바르지 않습니다.");
+        }
+
+        memberRepository.delete(member);
+        return new MemberDeleteResponse(true, "회원 탈퇴가 완료되었습니다.");
+    }
+
+    private Member findMemberByLoginId(String loginId) {
+        return memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UnauthorizedException("사용자를 찾을 수 없습니다."));
     }
 
     private void validateSignupRequest(SignupRequest request) {

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -5,10 +5,15 @@ import com.capstone.interview.dto.SessionCreateResponse;
 import com.capstone.interview.dto.SessionEndResponse;
 import com.capstone.interview.entity.CoverLetter;
 import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.Member;
 import com.capstone.interview.entity.Resume;
+import com.capstone.interview.exception.UnauthorizedException;
+import com.capstone.interview.repository.CoverLetterRepository;
 import com.capstone.interview.repository.InterviewRepository;
-import jakarta.persistence.EntityManager;
+import com.capstone.interview.repository.MemberRepository;
+import com.capstone.interview.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,8 +24,10 @@ import java.util.UUID;
 public class InterviewService {
 
     private final InterviewRepository interviewRepository;
+    private final MemberRepository memberRepository;
+    private final ResumeRepository resumeRepository;
+    private final CoverLetterRepository coverLetterRepository;
     private final LiveKitService liveKitService;
-    private final EntityManager entityManager;
 
     @Transactional
     public SessionCreateResponse createSession(SessionCreateRequest request) {
@@ -28,15 +35,26 @@ public class InterviewService {
             throw new IllegalArgumentException("jobField와 durationMinutes는 필수입니다.");
         }
 
-        Resume resume = request.resumeIds() != null
-                ? entityManager.getReference(Resume.class, request.resumeIds()) : null;
-        CoverLetter coverLetter = request.coverLetter() != null
-                ? entityManager.getReference(CoverLetter.class, request.coverLetter()) : null;
+        Resume resume = null;
+        if (request.resumeIds() != null) {
+            resume = resumeRepository.findById(request.resumeIds())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이력서입니다: " + request.resumeIds()));
+        }
+
+        CoverLetter coverLetter = null;
+        if (request.coverLetter() != null) {
+            coverLetter = coverLetterRepository.findById(request.coverLetter())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 자기소개서입니다: " + request.coverLetter()));
+        }
+
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UnauthorizedException("인증된 사용자를 찾을 수 없습니다."));
 
         String sessionId = "sess-" + UUID.randomUUID();
 
         Interview interview = Interview.builder()
-                .member(null) // TODO: 인증 구현 시 SecurityContext에서 member 추출로 교체
+                .member(member)
                 .resume(resume)
                 .coverLetter(coverLetter)
                 .category(request.jobField())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
- JwtAuthenticationFilter 추가: 모든 요청에서 Bearer 토큰 검증 후 SecurityContext 등록
- SecurityConfig 업데이트: CORS 활성화, OPTIONS 허용, signup/login 외 전 경로 인증 필수
- /v1/auth/me 엔드포인트 추가: GET(내 정보 조회), PUT(수정), DELETE(탈퇴)
- InterviewService: SecurityContext에서 실제 Member 조회로 member(null) TODO 해결
- ResumeRepository, CoverLetterRepository 추가 및 FK 검증 로직 보강
- ddl-auto: create → update로 변경 (서버 재시작 시 데이터 유지)

## 관련 Issue
- closes #이슈번호

## 변경 사항
- 무엇을 왜 변경했는지

## 접근 방식
- 어떤 방법으로 구현했는지
- 다른 방법을 고려했다면, 왜 채택하지 않았는지

## AI 사용 내역
- 어떤 부분에 AI를 사용했는지:
- 직접 확인하고 수정한 부분:

## 테스트
- 어떻게 테스트했는지 (스크린샷, 실행 결과 등)

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
