### PR TITLE
[Feature] 세션 생성 시 Agent Dispatch 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'io.livekit:livekit-server:0.6.1'
+	implementation 'io.livekit:livekit-server:0.12.1'
 	implementation 'me.paulschwarz:springboot4-dotenv:5.1.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/capstone/interview/dto/SessionCreateResponse.java
+++ b/src/main/java/com/capstone/interview/dto/SessionCreateResponse.java
@@ -6,7 +6,9 @@ public record SessionCreateResponse(
 ) {
     public record Data(
         String sessionId,
-        LiveKitInfo livekit
+        LiveKitInfo livekit,
+        int answerTimeLimitSeconds,
+        int totalDurationSeconds
     ) {}
 
     public record LiveKitInfo(

--- a/src/main/java/com/capstone/interview/entity/Interview.java
+++ b/src/main/java/com/capstone/interview/entity/Interview.java
@@ -32,8 +32,14 @@ public class Interview {
     @Column(name = "session_id", unique = true, nullable = false, length = 50)
     private String sessionId;
 
+    @Column(name = "room_name", length = 50)
+    private String roomName;
+
     @Column(nullable = false, length = 50)
     private String category;
+
+    @Column(name = "duration_minutes")
+    private Integer durationMinutes;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
@@ -49,12 +55,15 @@ public class Interview {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Interview(Member member, Resume resume, CoverLetter coverLetter, String category, String sessionId) {
+    public Interview(Member member, Resume resume, CoverLetter coverLetter,
+                     String category, String sessionId, String roomName, Integer durationMinutes) {
         this.member = member;
         this.resume = resume;
         this.coverLetter = coverLetter;
         this.category = category;
         this.sessionId = sessionId;
+        this.roomName = roomName;
+        this.durationMinutes = durationMinutes;
         this.status = InterviewStatus.READY;
     }
 

--- a/src/main/java/com/capstone/interview/entity/InterviewQna.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewQna.java
@@ -1,13 +1,15 @@
 package com.capstone.interview.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "interview_qnas")
+@Table(name = "interview_qnas",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"interview_id", "sequence_number"}))
 @Getter
 @NoArgsConstructor
 public class InterviewQna {
@@ -23,7 +25,7 @@ public class InterviewQna {
     @Column(name = "sequence_number", nullable = false)
     private Integer sequenceNumber;
 
-    @Column(name = "question_content", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "question_content", columnDefinition = "TEXT")
     private String questionContent;
 
     @Column(name = "answer_content", columnDefinition = "TEXT")
@@ -32,10 +34,12 @@ public class InterviewQna {
     @Column(name = "is_follow_up", nullable = false)
     private boolean isFollowUp = false;
 
-    // 셀프 참조: 꼬리질문인 경우 부모 질문 ID
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private InterviewQna parent;
+
+    @Column(name = "intent", length = 255)
+    private String intent;
 
     @Column(name = "model_answer", columnDefinition = "TEXT")
     private String modelAnswer;
@@ -46,11 +50,47 @@ public class InterviewQna {
     @Column(name = "audio_url", length = 1024)
     private String audioUrl;
 
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @Builder
+    public InterviewQna(Interview interview, Integer sequenceNumber, String questionContent,
+                        String answerContent, boolean isFollowUp, InterviewQna parent,
+                        String intent, LocalDateTime startedAt, LocalDateTime expiresAt) {
+        this.interview = interview;
+        this.sequenceNumber = sequenceNumber;
+        this.questionContent = questionContent;
+        this.answerContent = answerContent;
+        this.isFollowUp = isFollowUp;
+        this.parent = parent;
+        this.intent = intent;
+        this.startedAt = startedAt;
+        this.expiresAt = expiresAt;
+    }
+
+    public void updateAnswer(String answerContent) {
+        this.answerContent = answerContent;
+    }
+
+    public void updateQuestion(String questionContent, String intent, boolean isFollowUp) {
+        this.questionContent = questionContent;
+        this.intent = intent;
+        this.isFollowUp = isFollowUp;
+    }
+
+    public void updateTimer(LocalDateTime startedAt, LocalDateTime expiresAt) {
+        this.startedAt = startedAt;
+        this.expiresAt = expiresAt;
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/capstone/interview/repository/InterviewQnaRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewQnaRepository.java
@@ -1,0 +1,14 @@
+package com.capstone.interview.repository;
+
+import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.InterviewQna;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface InterviewQnaRepository extends JpaRepository<InterviewQna, Long> {
+
+    Optional<InterviewQna> findByInterviewAndSequenceNumber(Interview interview, Integer sequenceNumber);
+
+    int countByInterview(Interview interview);
+}

--- a/src/main/java/com/capstone/interview/service/AgentDispatchService.java
+++ b/src/main/java/com/capstone/interview/service/AgentDispatchService.java
@@ -1,0 +1,96 @@
+package com.capstone.interview.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.livekit.server.AccessToken;
+import io.livekit.server.RoomAdmin;
+import io.livekit.server.RoomName;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * LiveKit Agent Dispatch 서비스.
+ * Twirp HTTP API 를 사용하여 Agent Worker 에게 Job 을 배포한다.
+ */
+@Slf4j
+@Service
+public class AgentDispatchService {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+    private final String apiSecret;
+    private final String agentName;
+
+    public AgentDispatchService(
+            @Value("${livekit.url}") String livekitUrl,
+            @Value("${livekit.api-key}") String apiKey,
+            @Value("${livekit.api-secret}") String apiSecret,
+            @Value("${livekit.agent-name:interviewer-agent}") String agentName,
+            ObjectMapper objectMapper) {
+        String httpUrl = livekitUrl.replace("wss://", "https://").replace("ws://", "http://");
+        this.restClient = RestClient.builder().baseUrl(httpUrl).build();
+        this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+        this.apiSecret = apiSecret;
+        this.agentName = agentName;
+    }
+
+    /**
+     * Agent 를 dispatch 한다.
+     */
+    public void dispatch(String roomName, String sessionId, String jobRole,
+                         String resumeText, String coverLetterText,
+                         int totalDurationSeconds, int answerTimeLimitSeconds) {
+        try {
+            // metadata 구성
+            Map<String, Object> metadata = new LinkedHashMap<>();
+            metadata.put("sessionId", sessionId);
+            metadata.put("jobRole", jobRole);
+            metadata.put("resumeText", resumeText != null ? resumeText : "");
+            metadata.put("coverLetterText", coverLetterText != null ? coverLetterText : "");
+            metadata.put("totalDurationSeconds", totalDurationSeconds);
+            metadata.put("answerTimeLimitSeconds", answerTimeLimitSeconds);
+
+            String metadataJson = objectMapper.writeValueAsString(metadata);
+
+            // Twirp request body
+            Map<String, String> requestBody = new LinkedHashMap<>();
+            requestBody.put("room", roomName);
+            requestBody.put("agent_name", agentName);
+            requestBody.put("metadata", metadataJson);
+
+            // roomAdmin 권한의 JWT 생성
+            String token = generateRoomAdminToken(roomName);
+
+            log.info("[Agent Dispatch] room={}, agent={}, sessionId={}", roomName, agentName, sessionId);
+
+            restClient.post()
+                    .uri("/twirp/livekit.AgentDispatchService/CreateDispatch")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(objectMapper.writeValueAsString(requestBody))
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info("[Agent Dispatch 성공] sessionId={}", sessionId);
+        } catch (Exception e) {
+            log.error("[Agent Dispatch 실패] sessionId={}, error={}", sessionId, e.getMessage(), e);
+            throw new RuntimeException("Agent dispatch 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private String generateRoomAdminToken(String roomName) {
+        AccessToken token = new AccessToken(apiKey, apiSecret);
+        token.setName("backend-service");
+        token.setIdentity("backend-service");
+        token.addGrants(new RoomAdmin(true), new RoomName(roomName));
+        return token.toJwt();
+    }
+}

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -5,29 +5,38 @@ import com.capstone.interview.dto.SessionCreateResponse;
 import com.capstone.interview.dto.SessionEndResponse;
 import com.capstone.interview.entity.CoverLetter;
 import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.InterviewQna;
 import com.capstone.interview.entity.Member;
 import com.capstone.interview.entity.Resume;
 import com.capstone.interview.exception.UnauthorizedException;
 import com.capstone.interview.repository.CoverLetterRepository;
+import com.capstone.interview.repository.InterviewQnaRepository;
 import com.capstone.interview.repository.InterviewRepository;
 import com.capstone.interview.repository.MemberRepository;
 import com.capstone.interview.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InterviewService {
 
+    private static final int ANSWER_TIME_LIMIT_SECONDS = 90;
+
     private final InterviewRepository interviewRepository;
+    private final InterviewQnaRepository interviewQnaRepository;
     private final MemberRepository memberRepository;
     private final ResumeRepository resumeRepository;
     private final CoverLetterRepository coverLetterRepository;
     private final LiveKitService liveKitService;
+    private final AgentDispatchService agentDispatchService;
 
     @Transactional
     public SessionCreateResponse createSession(SessionCreateRequest request) {
@@ -52,6 +61,8 @@ public class InterviewService {
                 .orElseThrow(() -> new UnauthorizedException("인증된 사용자를 찾을 수 없습니다."));
 
         String sessionId = "sess-" + UUID.randomUUID();
+        String roomName = liveKitService.generateRoomName();
+        int totalDurationSeconds = request.durationMinutes() * 60;
 
         Interview interview = Interview.builder()
                 .member(member)
@@ -59,19 +70,48 @@ public class InterviewService {
                 .coverLetter(coverLetter)
                 .category(request.jobField())
                 .sessionId(sessionId)
+                .roomName(roomName)
+                .durationMinutes(request.durationMinutes())
                 .build();
 
         interview.start();
         interviewRepository.save(interview);
 
-        String roomName = liveKitService.generateRoomName();
-        String token = liveKitService.generateToken(roomName, "user-" + interview.getId());
+        // Agent Dispatch
+        String resumeText = resume != null ? resume.getOriginalText() : "";
+        String coverLetterText = coverLetter != null ? coverLetter.getOriginalText() : "";
+
+        try {
+            agentDispatchService.dispatch(
+                    roomName, sessionId, request.jobField(),
+                    resumeText, coverLetterText,
+                    totalDurationSeconds, ANSWER_TIME_LIMIT_SECONDS
+            );
+        } catch (Exception e) {
+            log.error("[세션 생성] Agent dispatch 실패, 세션을 FAILED 처리합니다. sessionId={}", sessionId, e);
+            interview.fail();
+            throw new RuntimeException("Agent dispatch에 실패했습니다. 잠시 후 다시 시도해주세요.");
+        }
+
+        // 첫 턴 초기화 (turnNumber=1)
+        LocalDateTime now = LocalDateTime.now();
+        InterviewQna firstTurn = InterviewQna.builder()
+                .interview(interview)
+                .sequenceNumber(1)
+                .startedAt(now)
+                .expiresAt(now.plusSeconds(ANSWER_TIME_LIMIT_SECONDS))
+                .build();
+        interviewQnaRepository.save(firstTurn);
+
+        String token = liveKitService.generateToken(roomName, "user-" + member.getId());
 
         return new SessionCreateResponse(
                 true,
                 new SessionCreateResponse.Data(
                         sessionId,
-                        new SessionCreateResponse.LiveKitInfo(roomName, liveKitService.getUrl(), token)
+                        new SessionCreateResponse.LiveKitInfo(roomName, liveKitService.getUrl(), token),
+                        ANSWER_TIME_LIMIT_SECONDS,
+                        totalDurationSeconds
                 )
         );
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ livekit:
   url: ${LIVEKIT_URL}
   api-key: ${LIVEKIT_API_KEY}
   api-secret: ${LIVEKIT_API_SECRET}
+  agent-name: ${LIVEKIT_AGENT_NAME:interviewer-agent}
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 변경 사항

### 기능 변경
- 세션 생성 시 LiveKit Agent가 자동으로 Room에 dispatch됨 (이전: 토큰만 발급하고 Agent 안 뜸)
- Agent에게 이력서/자소서 원문, 직무, 타이머 정보를 metadata로 전달
- dispatch 실패 시 세션 상태를 FAILED로 전이하고 500 에러 응답
- 세션 생성 직후 첫 턴(turn 1) 자동 초기화 — 답변 타이머 시작
- 세션 생성 응답에 `answerTimeLimitSeconds(90)`, `totalDurationSeconds` 추가 → 프론트가 타이머 정보를 바로 사용 가능

### 코드 변경
- LiveKit SDK 0.6.1 → 0.12.1 업그레이드
- `AgentDispatchService` 신설 (Twirp HTTP API 기반)
- `Interview` 엔티티에 `roomName`, `durationMinutes` 필드 추가
- `InterviewQna` 엔티티에 `intent`, `startedAt`, `expiresAt` 필드 + 유니크 제약 추가
- `InterviewQnaRepository` 신설

## 접근 방식
- LiveKit SDK 내부 클래스 대신 Twirp HTTP API(`/twirp/livekit.AgentDispatchService/CreateDispatch`) 직접 호출
  - SDK 버전별 클래스 호환성 이슈를 피하고, LiveKit 공식 문서 기반으로 안정적 구현
- roomAdmin 권한 JWT를 AccessToken으로 생성하여 인증

## AI 사용 내역
- 어떤 부분에 AI를 사용했는지: 전체 구현
- 직접 확인하고 수정한 부분: compileJava 빌드 성공 확인

## 테스트
- `./gradlew compileJava` BUILD SUCCESSFUL
- 런타임 통합 테스트는 LiveKit Cloud 환경에서 수행 필요

## 머지 전 체크리스트
- [x] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
