### PR TITLE
[Feature] /next · /end 엔드포인트 및 Data Message 전송

### DIFF
--- a/src/main/java/com/capstone/interview/controller/InterviewController.java
+++ b/src/main/java/com/capstone/interview/controller/InterviewController.java
@@ -1,5 +1,7 @@
 package com.capstone.interview.controller;
 
+import com.capstone.interview.dto.NextTurnRequest;
+import com.capstone.interview.dto.NextTurnResponse;
 import com.capstone.interview.dto.SessionCreateRequest;
 import com.capstone.interview.dto.SessionCreateResponse;
 import com.capstone.interview.dto.SessionEndRequest;
@@ -25,6 +27,17 @@ public class InterviewController {
 
         SessionCreateResponse response = interviewService.createSession(request);
         log.info("[세션 생성 성공] sessionId={}", response.data().sessionId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{sessionId}/next")
+    public ResponseEntity<NextTurnResponse> nextTurn(
+            @PathVariable String sessionId,
+            @RequestBody NextTurnRequest request) {
+        log.info("[다음 질문 요청] sessionId={}, currentTurnNumber={}", sessionId, request.currentTurnNumber());
+
+        NextTurnResponse response = interviewService.nextTurn(sessionId, request);
+        log.info("[다음 질문 성공] sessionId={}, nextTurn={}", sessionId, response.data().turnNumber());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/capstone/interview/dto/NextTurnRequest.java
+++ b/src/main/java/com/capstone/interview/dto/NextTurnRequest.java
@@ -1,0 +1,5 @@
+package com.capstone.interview.dto;
+
+public record NextTurnRequest(
+    Integer currentTurnNumber
+) {}

--- a/src/main/java/com/capstone/interview/dto/NextTurnResponse.java
+++ b/src/main/java/com/capstone/interview/dto/NextTurnResponse.java
@@ -1,0 +1,14 @@
+package com.capstone.interview.dto;
+
+import java.time.LocalDateTime;
+
+public record NextTurnResponse(
+    boolean success,
+    NextTurnResponse.Data data
+) {
+    public record Data(
+        int turnNumber,
+        LocalDateTime startedAt,
+        LocalDateTime expiresAt
+    ) {}
+}

--- a/src/main/java/com/capstone/interview/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/interview/exception/GlobalExceptionHandler.java
@@ -36,6 +36,26 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(401).body(error);
     }
 
+    /** 세션 없음 (404) */
+    @ExceptionHandler(SessionNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleSessionNotFound(SessionNotFoundException e) {
+        log.warn("[세션 없음] {}", e.getMessage());
+        ErrorResponse error = new ErrorResponse(
+            404, "SESSION_NOT_FOUND", e.getMessage(), LocalDateTime.now()
+        );
+        return ResponseEntity.status(404).body(error);
+    }
+
+    /** 상태 불일치 (409) — 잘못된 상태 전이 */
+    @ExceptionHandler(InvalidStateException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidState(InvalidStateException e) {
+        log.warn("[상태 불일치] {}", e.getMessage());
+        ErrorResponse error = new ErrorResponse(
+            409, "INVALID_STATE", e.getMessage(), LocalDateTime.now()
+        );
+        return ResponseEntity.status(409).body(error);
+    }
+
     /** 리소스 충돌 (409) — 중복된 아이디 등 */
     @ExceptionHandler(ConflictException.class)
     public ResponseEntity<ErrorResponse> handleConflict(ConflictException e) {

--- a/src/main/java/com/capstone/interview/exception/InvalidStateException.java
+++ b/src/main/java/com/capstone/interview/exception/InvalidStateException.java
@@ -1,0 +1,7 @@
+package com.capstone.interview.exception;
+
+public class InvalidStateException extends RuntimeException {
+    public InvalidStateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/interview/exception/SessionNotFoundException.java
+++ b/src/main/java/com/capstone/interview/exception/SessionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.capstone.interview.exception;
+
+public class SessionNotFoundException extends RuntimeException {
+    public SessionNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -1,13 +1,18 @@
 package com.capstone.interview.service;
 
+import com.capstone.interview.dto.NextTurnRequest;
+import com.capstone.interview.dto.NextTurnResponse;
 import com.capstone.interview.dto.SessionCreateRequest;
 import com.capstone.interview.dto.SessionCreateResponse;
 import com.capstone.interview.dto.SessionEndResponse;
 import com.capstone.interview.entity.CoverLetter;
 import com.capstone.interview.entity.Interview;
 import com.capstone.interview.entity.InterviewQna;
+import com.capstone.interview.entity.InterviewStatus;
 import com.capstone.interview.entity.Member;
 import com.capstone.interview.entity.Resume;
+import com.capstone.interview.exception.InvalidStateException;
+import com.capstone.interview.exception.SessionNotFoundException;
 import com.capstone.interview.exception.UnauthorizedException;
 import com.capstone.interview.repository.CoverLetterRepository;
 import com.capstone.interview.repository.InterviewQnaRepository;
@@ -21,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
@@ -36,6 +42,7 @@ public class InterviewService {
     private final ResumeRepository resumeRepository;
     private final CoverLetterRepository coverLetterRepository;
     private final LiveKitService liveKitService;
+    private final LiveKitRoomService liveKitRoomService;
     private final AgentDispatchService agentDispatchService;
 
     @Transactional
@@ -117,10 +124,71 @@ public class InterviewService {
     }
 
     @Transactional
-    public SessionEndResponse endSession(String sessionId, String reason) {
-        Interview interview = interviewRepository.findBySessionId(sessionId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다: " + sessionId));
+    public NextTurnResponse nextTurn(String sessionId, NextTurnRequest request) {
+        Interview interview = findInterviewOrThrow(sessionId);
+        verifyOwner(interview);
+        verifyInProgress(interview);
 
+        // 현재 턴 번호 검증
+        int currentTurn = interviewQnaRepository.countByInterview(interview);
+        if (request.currentTurnNumber() != null && !request.currentTurnNumber().equals(currentTurn)) {
+            log.warn("[/next] 턴 번호 불일치. 클라이언트={}, 서버={}", request.currentTurnNumber(), currentTurn);
+        }
+
+        int nextTurnNumber = currentTurn + 1;
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiresAt = now.plusSeconds(ANSWER_TIME_LIMIT_SECONDS);
+
+        // 다음 턴 레코드 생성
+        InterviewQna nextQna = InterviewQna.builder()
+                .interview(interview)
+                .sequenceNumber(nextTurnNumber)
+                .startedAt(now)
+                .expiresAt(expiresAt)
+                .build();
+        interviewQnaRepository.save(nextQna);
+
+        // Agent 에 NEXT Data Message 전송 — 실패 시 롤백
+        try {
+            Map<String, Object> message = Map.of(
+                    "type", "NEXT",
+                    "payload", Map.of("turnNumber", nextTurnNumber)
+            );
+            liveKitRoomService.sendData(interview.getRoomName(), message);
+        } catch (Exception e) {
+            log.error("[/next] sendData 실패, 턴 증가를 롤백합니다. sessionId={}", sessionId, e);
+            // 롤백: 방금 생성한 턴 레코드 삭제
+            interviewQnaRepository.delete(nextQna);
+            throw new RuntimeException("Agent에 다음 질문 신호 전송에 실패했습니다. 다시 시도해주세요.");
+        }
+
+        return new NextTurnResponse(
+                true,
+                new NextTurnResponse.Data(nextTurnNumber, now, expiresAt)
+        );
+    }
+
+    @Transactional
+    public SessionEndResponse endSession(String sessionId, String reason) {
+        Interview interview = findInterviewOrThrow(sessionId);
+        verifyOwner(interview);
+        verifyInProgress(interview);
+
+        // 1. Agent 에 END 메시지 전송 (실패해도 계속 진행)
+        try {
+            Map<String, Object> message = Map.of(
+                    "type", "END",
+                    "payload", Map.of("reason", reason != null ? reason : "USER_STOP")
+            );
+            liveKitRoomService.sendData(interview.getRoomName(), message);
+        } catch (Exception e) {
+            log.warn("[/end] sendData(END) 실패, deleteRoom으로 정리합니다. sessionId={}", sessionId);
+        }
+
+        // 2. Room 삭제 — Agent 강제 연결 종료
+        liveKitRoomService.deleteRoom(interview.getRoomName());
+
+        // 3. 세션 상태 COMPLETED 전환
         interview.complete();
 
         return new SessionEndResponse(
@@ -128,5 +196,25 @@ public class InterviewService {
                 "면접이 종료되었습니다. AI 피드백을 생성 중입니다.",
                 new SessionEndResponse.Data(interview.getStatus().name())
         );
+    }
+
+    private Interview findInterviewOrThrow(String sessionId) {
+        return interviewRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new SessionNotFoundException("존재하지 않는 세션입니다: " + sessionId));
+    }
+
+    private void verifyOwner(Interview interview) {
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
+        Member member = interview.getMember();
+        if (member == null || !member.getLoginId().equals(loginId)) {
+            throw new UnauthorizedException("본인의 면접 세션만 제어할 수 있습니다.");
+        }
+    }
+
+    private void verifyInProgress(Interview interview) {
+        if (interview.getStatus() != InterviewStatus.IN_PROGRESS) {
+            throw new InvalidStateException(
+                    "IN_PROGRESS 상태에서만 가능합니다. 현재: " + interview.getStatus());
+        }
     }
 }

--- a/src/main/java/com/capstone/interview/service/LiveKitRoomService.java
+++ b/src/main/java/com/capstone/interview/service/LiveKitRoomService.java
@@ -1,0 +1,104 @@
+package com.capstone.interview.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.livekit.server.AccessToken;
+import io.livekit.server.RoomAdmin;
+import io.livekit.server.RoomName;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * LiveKit Room 관리 서비스.
+ * Twirp HTTP API 를 사용하여 Data Message 전송 및 Room 삭제를 수행한다.
+ */
+@Slf4j
+@Service
+public class LiveKitRoomService {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+    private final String apiSecret;
+
+    public LiveKitRoomService(
+            @Value("${livekit.url}") String livekitUrl,
+            @Value("${livekit.api-key}") String apiKey,
+            @Value("${livekit.api-secret}") String apiSecret,
+            ObjectMapper objectMapper) {
+        String httpUrl = livekitUrl.replace("wss://", "https://").replace("ws://", "http://");
+        this.restClient = RestClient.builder().baseUrl(httpUrl).build();
+        this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+        this.apiSecret = apiSecret;
+    }
+
+    /**
+     * Room 에 Data Message 를 전송한다.
+     * 실패 시 RuntimeException 을 던진다.
+     */
+    public void sendData(String roomName, Map<String, Object> message) {
+        try {
+            String token = generateRoomAdminToken(roomName);
+            String messageJson = objectMapper.writeValueAsString(message);
+            String dataBase64 = Base64.getEncoder().encodeToString(messageJson.getBytes());
+
+            Map<String, Object> requestBody = Map.of(
+                    "room", roomName,
+                    "data", dataBase64,
+                    "kind", "RELIABLE"
+            );
+
+            restClient.post()
+                    .uri("/twirp/livekit.RoomService/SendData")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(objectMapper.writeValueAsString(requestBody))
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info("[SendData 성공] room={}", roomName);
+        } catch (Exception e) {
+            log.error("[SendData 실패] room={}, error={}", roomName, e.getMessage(), e);
+            throw new RuntimeException("Data Message 전송 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Room 을 삭제한다. Agent 강제 연결 종료 용도.
+     * 실패해도 예외를 던지지 않고 로그만 남긴다.
+     */
+    public void deleteRoom(String roomName) {
+        try {
+            String token = generateRoomAdminToken(roomName);
+
+            Map<String, String> requestBody = Map.of("room", roomName);
+
+            restClient.post()
+                    .uri("/twirp/livekit.RoomService/DeleteRoom")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(objectMapper.writeValueAsString(requestBody))
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info("[DeleteRoom 성공] room={}", roomName);
+        } catch (Exception e) {
+            log.warn("[DeleteRoom 실패] room={}, error={} — 무시하고 계속 진행", roomName, e.getMessage());
+        }
+    }
+
+    private String generateRoomAdminToken(String roomName) {
+        AccessToken token = new AccessToken(apiKey, apiSecret);
+        token.setName("backend-service");
+        token.setIdentity("backend-service");
+        token.addGrants(new RoomAdmin(true), new RoomName(roomName));
+        return token.toJwt();
+    }
+}


### PR DESCRIPTION
## 변경 사항

### 기능 변경
- `POST /v1/interviews/sessions/{id}/next` 신설
  - "다음 질문" 버튼 또는 답변 타이머 만료 시 호출
  - 턴 번호 증가 + 답변 타이머(startedAt/expiresAt) 기록
  - Agent에게 NEXT Data Message 전송 → Agent가 다음 질문 생성·발화
  - sendData 실패 시 턴 증가 롤백 + 500 응답 (원자성 보장)
- `POST /v1/interviews/sessions/{id}/end` 보강
  - Agent에게 END Data Message 전송 (마지막 턴 저장 트리거)
  - 실패해도 deleteRoom()으로 Room 강제 정리 → Agent 프로세스 종료
- 두 엔드포인트 모두 **소유자 검증** 추가 (타인 세션 접근 차단)
- 세션 상태가 IN_PROGRESS가 아니면 409 INVALID_STATE 응답
- 존재하지 않는 세션 접근 시 404 SESSION_NOT_FOUND 응답

### 코드 변경
- `LiveKitRoomService` 신설 — Twirp HTTP API 기반 sendData/deleteRoom
- `SessionNotFoundException(404)`, `InvalidStateException(409)` 예외 클래스 추가
- `GlobalExceptionHandler`에 매핑 추가
- `NextTurnRequest`, `NextTurnResponse` DTO 추가

## 접근 방식
- sendData/deleteRoom도 Twirp HTTP API 직접 호출 (이슈 1의 dispatch와 동일 패턴)
- /next의 원자성: sendData 성공 확인 후에만 턴 레코드 유지, 실패 시 즉시 삭제
- /end는 §4.4 계약대로 실패해도 롤백하지 않고 deleteRoom으로 정리

## AI 사용 내역
- 어떤 부분에 AI를 사용했는지: 전체 구현
- 직접 확인하고 수정한 부분: compileJava 빌드 성공 확인

## 테스트
- `./gradlew compileJava` BUILD SUCCESSFUL
- 런타임 통합 테스트는 LiveKit Cloud + Agent 환경에서 수행 필요

## 머지 전 체크리스트
- [x] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
