### PR TITLE
[Feature] Agent QnA 저장 내부 API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ JWT_SECRET=change-me-to-a-random-string-of-at-least-32-chars
 LIVEKIT_URL=
 LIVEKIT_API_KEY=
 LIVEKIT_API_SECRET=
+
+# --- Internal Service Token ---
+# Agent → Backend 서버 간 통신용 공유 secret.
+# Agent 쪽 .env 와 동일한 값을 설정해야 합니다.
+# 생성 예시: openssl rand -base64 32
+INTERNAL_SERVICE_TOKEN=change-me-to-a-shared-secret

--- a/src/main/java/com/capstone/interview/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/interview/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ServiceTokenFilter serviceTokenFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -30,8 +31,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/v1/auth/signup", "/v1/auth/login").permitAll()
+                        .requestMatchers("/internal/**").permitAll()
                         .anyRequest().authenticated())
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(serviceTokenFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/capstone/interview/config/ServiceTokenFilter.java
+++ b/src/main/java/com/capstone/interview/config/ServiceTokenFilter.java
@@ -1,0 +1,50 @@
+package com.capstone.interview.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * /internal/** 경로 전용 서비스 토큰 검증 필터.
+ * Agent → Backend 서버 간 통신에 사용되는 공유 secret 헤더를 검증한다.
+ */
+@Slf4j
+@Component
+public class ServiceTokenFilter extends OncePerRequestFilter {
+
+    private static final String SERVICE_TOKEN_HEADER = "X-Service-Token";
+
+    @Value("${internal.service-token}")
+    private String expectedToken;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        // /internal/** 경로만 이 필터를 적용
+        return !request.getRequestURI().startsWith("/internal/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = request.getHeader(SERVICE_TOKEN_HEADER);
+
+        if (token == null || !token.equals(expectedToken)) {
+            log.warn("[ServiceToken 검증 실패] URI={}, token={}", request.getRequestURI(),
+                    token == null ? "null" : "invalid");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(
+                    "{\"status\":401,\"code\":\"UNAUTHORIZED\",\"message\":\"유효하지 않은 서비스 토큰입니다.\"}");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/capstone/interview/controller/InternalQnaController.java
+++ b/src/main/java/com/capstone/interview/controller/InternalQnaController.java
@@ -1,0 +1,30 @@
+package com.capstone.interview.controller;
+
+import com.capstone.interview.dto.InternalQnaRequest;
+import com.capstone.interview.service.InternalQnaService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/internal/v1/interviews/sessions")
+@RequiredArgsConstructor
+public class InternalQnaController {
+
+    private final InternalQnaService internalQnaService;
+
+    @PostMapping("/{sessionId}/qnas")
+    public ResponseEntity<Map<String, Boolean>> saveQna(
+            @PathVariable String sessionId,
+            @RequestBody InternalQnaRequest request) {
+        log.info("[QnA 저장] sessionId={}, turnNumber={}", sessionId, request.turnNumber());
+
+        internalQnaService.upsertQna(sessionId, request);
+
+        return ResponseEntity.ok(Map.of("success", true));
+    }
+}

--- a/src/main/java/com/capstone/interview/dto/InternalQnaRequest.java
+++ b/src/main/java/com/capstone/interview/dto/InternalQnaRequest.java
@@ -1,0 +1,9 @@
+package com.capstone.interview.dto;
+
+public record InternalQnaRequest(
+    Integer turnNumber,
+    String question,
+    String intent,
+    Boolean isFollowUp,
+    String answer
+) {}

--- a/src/main/java/com/capstone/interview/service/InternalQnaService.java
+++ b/src/main/java/com/capstone/interview/service/InternalQnaService.java
@@ -1,0 +1,63 @@
+package com.capstone.interview.service;
+
+import com.capstone.interview.dto.InternalQnaRequest;
+import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.InterviewQna;
+import com.capstone.interview.exception.SessionNotFoundException;
+import com.capstone.interview.repository.InterviewQnaRepository;
+import com.capstone.interview.repository.InterviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InternalQnaService {
+
+    private final InterviewRepository interviewRepository;
+    private final InterviewQnaRepository interviewQnaRepository;
+
+    /**
+     * Agent 가 매 턴 전송하는 Q+A 를 upsert 한다.
+     * (session_id, turn_number) 유니크 제약 기반 — 같은 턴이 재시도로 두 번 도착해도
+     * DB 는 최종 상태 하나만 유지한다.
+     */
+    @Transactional
+    public void upsertQna(String sessionId, InternalQnaRequest request) {
+        Interview interview = interviewRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new SessionNotFoundException("존재하지 않는 세션입니다: " + sessionId));
+
+        InterviewQna existing = interviewQnaRepository
+                .findByInterviewAndSequenceNumber(interview, request.turnNumber())
+                .orElse(null);
+
+        if (existing != null) {
+            // upsert: 기존 레코드 업데이트
+            if (request.question() != null) {
+                existing.updateQuestion(
+                        request.question(),
+                        request.intent(),
+                        request.isFollowUp() != null && request.isFollowUp()
+                );
+            }
+            if (request.answer() != null) {
+                existing.updateAnswer(request.answer());
+            }
+            log.info("[QnA upsert] 기존 턴 업데이트. sessionId={}, turn={}", sessionId, request.turnNumber());
+        } else {
+            // insert: 새 레코드 생성
+            InterviewQna newQna = InterviewQna.builder()
+                    .interview(interview)
+                    .sequenceNumber(request.turnNumber())
+                    .questionContent(request.question())
+                    .answerContent(request.answer() != null ? request.answer() : "")
+                    .isFollowUp(request.isFollowUp() != null && request.isFollowUp())
+                    .intent(request.intent())
+                    .build();
+            interviewQnaRepository.save(newQna);
+            log.info("[QnA insert] 새 턴 저장. sessionId={}, turn={}", sessionId, request.turnNumber());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,6 @@ livekit:
 jwt:
   secret: ${JWT_SECRET}
   expiration: 3600000  # 1시간 (밀리초). 리프레쉬 토큰 추가시 짧게 바꿔야 함.
+
+internal:
+  service-token: ${INTERNAL_SERVICE_TOKEN:default-dev-token}


### PR DESCRIPTION
## 변경 사항

### 기능 변경
- Agent가 매 턴 Q+A를 실시간 저장할 수 있는 내부 API 추가
  - `POST /internal/v1/interviews/sessions/{sessionId}/qnas`
  - 같은 턴이 재시도로 두 번 도착해도 DB는 최종 상태 하나만 유지 (upsert)
  - answer 빈 문자열 허용 (사용자 무응답 턴)
- `/internal/**` 경로 전용 서비스 토큰 인증 도입
  - `X-Service-Token` 헤더로 Agent ↔ Backend 간 공유 secret 검증
  - JWT 인증과 분리 — 외부 사용자는 접근 불가

### 코드 변경
- `InternalQnaController`, `InternalQnaService`, `InternalQnaRequest` 추가
- `ServiceTokenFilter` 추가 (`/internal/**` 경로만 적용)
- `SecurityConfig` 수정: `/internal/**` permitAll + ServiceTokenFilter 체인 등록
- `application.yml`에 `internal.service-token` 설정 추가
- `.env.example`에 `INTERNAL_SERVICE_TOKEN` 항목 추가

## 접근 방식
- Spring Security의 permitAll로 JWT 검증을 우회하되, 별도 ServiceTokenFilter로 서비스 간 인증 보장
  - 단순 permitAll만 하면 외부에서도 호출 가능해지므로 반드시 필터 필요 (INTEGRATION_CONTRACT §5.5 주의 1)
- upsert는 JPA 조회 후 update/insert 분기 방식 (DB 벤더 독립적)

## AI 사용 내역
- 어떤 부분에 AI를 사용했는지: 전체 구현
- 직접 확인하고 수정한 부분: compileJava 빌드 성공 확인

## 테스트
- `./gradlew compileJava` BUILD SUCCESSFUL
- 런타임 테스트: Agent에서 `X-Service-Token` 헤더와 함께 POST 호출 시 정상 저장 확인 필요

## 머지 전 체크리스트
- [x] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
