### PR TITLE
fix: ObjectMapper 빈 등록 및 CORS OPTIONS 메서드 추가

### DIFF
--- a/src/main/java/com/capstone/interview/config/WebConfig.java
+++ b/src/main/java/com/capstone/interview/config/WebConfig.java
@@ -1,5 +1,7 @@
 package com.capstone.interview.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,10 +9,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")  // 배포 시 프론트 URL로 교체
-                .allowedMethods("GET", "POST", "PUT", "DELETE");
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
     }
 }


### PR DESCRIPTION
## 문제
LiveKitRoomService가 ObjectMapper를 생성자 주입 받는데 Spring이 ObjectMapper 빈을 자동 등록하지 않아 서버 기동 실패.

## 수정 내용
- `WebConfig`에 `ObjectMapper` `@Bean` 추가
- CORS 허용 메서드에 `OPTIONS` 추가

## 영향
- EC2 서버 기동 실패 → 정상 기동으로 복구

Made with [Cursor](https://cursor.com)