### PR TITLE
feat: 이력서 PDF 파싱 및 DB 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	implementation 'org.apache.pdfbox:pdfbox:3.0.3'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/capstone/interview/controller/ResumeController.java
+++ b/src/main/java/com/capstone/interview/controller/ResumeController.java
@@ -1,0 +1,89 @@
+package com.capstone.interview.controller;
+
+import com.capstone.interview.dto.ResumeResponse;
+import com.capstone.interview.dto.ResumeUploadRequest;
+import com.capstone.interview.service.ResumeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * 이력서 업로드 및 조회 API.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/v1/resumes")
+@RequiredArgsConstructor
+public class ResumeController {
+
+    private final ResumeService resumeService;
+
+    /**
+     * PDF 이력서 업로드.
+     * POST /v1/resumes/upload-pdf
+     */
+    @PostMapping("/upload-pdf")
+    public ResponseEntity<ResumeResponse> uploadPdf(
+            Authentication authentication,
+            @RequestParam("title") String title,
+            @RequestParam("file") MultipartFile file) throws IOException {
+
+        String loginId = authentication.getName();
+        log.info("[이력서 PDF 업로드] loginId={}, title={}, fileSize={}",
+                loginId, title, file.getSize());
+
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.equals("application/pdf")) {
+            throw new IllegalArgumentException("PDF 파일만 업로드 가능합니다.");
+        }
+
+        ResumeResponse response = resumeService.uploadPdfResume(loginId, title, file);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 텍스트 이력서 직접 입력.
+     * POST /v1/resumes/upload-text
+     */
+    @PostMapping("/upload-text")
+    public ResponseEntity<ResumeResponse> uploadText(
+            Authentication authentication,
+            @RequestBody ResumeUploadRequest request) {
+
+        String loginId = authentication.getName();
+        log.info("[이력서 텍스트 입력] loginId={}, title={}", loginId, request.title());
+
+        ResumeResponse response = resumeService.uploadTextResume(loginId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 내 이력서 목록 조회.
+     * GET /v1/resumes
+     */
+    @GetMapping
+    public ResponseEntity<List<ResumeResponse>> getMyResumes(Authentication authentication) {
+        String loginId = authentication.getName();
+        return ResponseEntity.ok(resumeService.getResumesByLoginId(loginId));
+    }
+
+    /**
+     * 이력서 상세 조회.
+     * GET /v1/resumes/{id}
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ResumeResponse> getResume(@PathVariable Long id) {
+        return ResponseEntity.ok(resumeService.getResume(id));
+    }
+}

--- a/src/main/java/com/capstone/interview/dto/ResumeResponse.java
+++ b/src/main/java/com/capstone/interview/dto/ResumeResponse.java
@@ -1,0 +1,15 @@
+package com.capstone.interview.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이력서 응답 DTO.
+ */
+public record ResumeResponse(
+        Long id,
+        String title,
+        String originalText,
+        String fileUrl,
+        String keywords,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/capstone/interview/dto/ResumeUploadRequest.java
+++ b/src/main/java/com/capstone/interview/dto/ResumeUploadRequest.java
@@ -1,0 +1,9 @@
+package com.capstone.interview.dto;
+
+/**
+ * 텍스트 이력서 직접 입력 요청.
+ */
+public record ResumeUploadRequest(
+        String title,
+        String originalText
+) {}

--- a/src/main/java/com/capstone/interview/entity/Resume.java
+++ b/src/main/java/com/capstone/interview/entity/Resume.java
@@ -1,6 +1,7 @@
 package com.capstone.interview.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,6 +43,27 @@ public class Resume {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @Builder
+    private Resume(Member member, String title, String originalText, String fileUrl, String keywords) {
+        this.member = member;
+        this.title = title;
+        this.originalText = originalText;
+        this.fileUrl = fileUrl;
+        this.keywords = keywords;
+    }
+
+    public void updateOriginalText(String originalText) {
+        this.originalText = originalText;
+    }
+
+    public void updateFileUrl(String fileUrl) {
+        this.fileUrl = fileUrl;
+    }
+
+    public void updateKeywords(String keywords) {
+        this.keywords = keywords;
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/capstone/interview/repository/ResumeRepository.java
+++ b/src/main/java/com/capstone/interview/repository/ResumeRepository.java
@@ -3,5 +3,9 @@ package com.capstone.interview.repository;
 import com.capstone.interview.entity.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
+
+    List<Resume> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/capstone/interview/service/PdfParserService.java
+++ b/src/main/java/com/capstone/interview/service/PdfParserService.java
@@ -1,0 +1,38 @@
+package com.capstone.interview.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * PDF 파일을 텍스트로 변환하는 서비스.
+ * Apache PDFBox를 사용한다.
+ */
+@Slf4j
+@Service
+public class PdfParserService {
+
+    /**
+     * 업로드된 PDF 파일에서 텍스트를 추출한다.
+     *
+     * @param file 업로드된 PDF 파일
+     * @return 추출된 텍스트
+     * @throws IOException PDF 읽기 실패 시
+     */
+    public String extractText(MultipartFile file) throws IOException {
+        try (InputStream inputStream = file.getInputStream();
+             PDDocument document = PDDocument.load(inputStream)) {
+
+            PDFTextStripper stripper = new PDFTextStripper();
+            String text = stripper.getText(document);
+
+            log.info("[PDF 파싱] 완료: {}페이지, {}글자", document.getNumberOfPages(), text.length());
+            return text.trim();
+        }
+    }
+}

--- a/src/main/java/com/capstone/interview/service/ResumeService.java
+++ b/src/main/java/com/capstone/interview/service/ResumeService.java
@@ -1,0 +1,119 @@
+package com.capstone.interview.service;
+
+import com.capstone.interview.dto.ResumeResponse;
+import com.capstone.interview.dto.ResumeUploadRequest;
+import com.capstone.interview.entity.Member;
+import com.capstone.interview.entity.Resume;
+import com.capstone.interview.repository.MemberRepository;
+import com.capstone.interview.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * 이력서 업로드 및 관리 서비스.
+ * PDF 파싱 → 텍스트 추출 → DB 저장을 처리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+
+    private final PdfParserService pdfParserService;
+    private final ResumeRepository resumeRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * PDF 이력서를 업로드하고 파싱하여 DB에 저장한다.
+     */
+    @Transactional
+    public ResumeResponse uploadPdfResume(String loginId, String title, MultipartFile file)
+            throws IOException {
+
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        // PDF → 텍스트 변환
+        String originalText = pdfParserService.extractText(file);
+
+        if (originalText.isBlank()) {
+            throw new IllegalArgumentException("PDF에서 텍스트를 추출할 수 없습니다.");
+        }
+
+        // DB 저장
+        Resume resume = Resume.builder()
+                .member(member)
+                .title(title)
+                .originalText(originalText)
+                .build();
+
+        Resume saved = resumeRepository.save(resume);
+        log.info("[이력서 저장] id={}, memberId={}, 텍스트 길이={}",
+                saved.getId(), member.getId(), originalText.length());
+
+        return toResponse(saved);
+    }
+
+    /**
+     * 텍스트로 직접 입력한 이력서를 DB에 저장한다.
+     */
+    @Transactional
+    public ResumeResponse uploadTextResume(String loginId, ResumeUploadRequest request) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        if (request.originalText() == null || request.originalText().isBlank()) {
+            throw new IllegalArgumentException("이력서 텍스트가 비어있습니다.");
+        }
+
+        Resume resume = Resume.builder()
+                .member(member)
+                .title(request.title())
+                .originalText(request.originalText())
+                .build();
+
+        Resume saved = resumeRepository.save(resume);
+        log.info("[이력서 저장] id={}, memberId={}", saved.getId(), member.getId());
+
+        return toResponse(saved);
+    }
+
+    /**
+     * 회원의 이력서 목록을 조회한다.
+     */
+    @Transactional(readOnly = true)
+    public List<ResumeResponse> getResumesByLoginId(String loginId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        return resumeRepository.findByMemberId(member.getId()).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /**
+     * 이력서 ID로 조회한다.
+     */
+    @Transactional(readOnly = true)
+    public ResumeResponse getResume(Long resumeId) {
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new IllegalArgumentException("이력서를 찾을 수 없습니다: " + resumeId));
+        return toResponse(resume);
+    }
+
+    private ResumeResponse toResponse(Resume resume) {
+        return new ResumeResponse(
+                resume.getId(),
+                resume.getTitle(),
+                resume.getOriginalText(),
+                resume.getFileUrl(),
+                resume.getKeywords(),
+                resume.getCreatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## 관련 Issue
- closes #이슈번호

## 변경 사항
- Resume 엔티티에 @Builder, update 메서드 추가
- PdfParserService: Apache PDFBox로 PDF → 텍스트 변환
- ResumeService: PDF 파싱 + DB 저장, 텍스트 직접 입력, 목록/상세 조회
- ResumeController: REST API 4개 엔드포인트 (/v1/resumes/*)
- build.gradle에 pdfbox:3.0.3 의존성 추가

## API
| 메서드 | 경로 | 설명 |
|--------|------|------|
| POST | /v1/resumes/upload-pdf | PDF 업로드 + 파싱 + 저장 |
| POST | /v1/resumes/upload-text | 텍스트 직접 입력 + 저장 |
| GET | /v1/resumes | 내 이력서 목록 조회 |
| GET | /v1/resumes/{id} | 이력서 상세 조회 |

## 테스트
- PDF 텍스트 추출 로컬 테스트 완료

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
