### PR TITLE
fix: PDFBox 3.x Loader.loadPDF(byte[]) 호환 수정

### DIFF
--- a/src/main/java/com/capstone/interview/service/PdfParserService.java
+++ b/src/main/java/com/capstone/interview/service/PdfParserService.java
@@ -1,19 +1,17 @@
 package com.capstone.interview.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import org.apache.pdfbox.Loader; // 머지 오류 해결
-
 import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * PDF 파일을 텍스트로 변환하는 서비스.
- * Apache PDFBox를 사용한다.
+ * Apache PDFBox 3.x를 사용한다.
  */
 @Slf4j
 @Service
@@ -21,17 +19,15 @@ public class PdfParserService {
 
     /**
      * 업로드된 PDF 파일에서 텍스트를 추출한다.
+     * PDFBox 3.x에서는 Loader.loadPDF(byte[])를 사용해야 한다.
      *
      * @param file 업로드된 PDF 파일
      * @return 추출된 텍스트
      * @throws IOException PDF 읽기 실패 시
      */
     public String extractText(MultipartFile file) throws IOException {
-        try (InputStream inputStream = file.getInputStream();
-             
-             // load를 Loader.loadPDF로!
-            PDDocument document = Loader.loadPDF(inputStream)) {
-            // PDDocument document = PDDocument.load(inputStream)) {
+        byte[] bytes = file.getBytes();
+        try (PDDocument document = Loader.loadPDF(bytes)) {
 
             PDFTextStripper stripper = new PDFTextStripper();
             String text = stripper.getText(document);


### PR DESCRIPTION
## 관련 Issue
- closes #이슈번호

## 변경 사항
- PdfParserService에서 PDFBox 3.x 빌드 에러 수정
- `Loader.loadPDF(InputStream)` → `Loader.loadPDF(byte[])` 로 변경

## 접근 방식
- PDFBox 3.x에서 `PDDocument.load(InputStream)`과 `Loader.loadPDF(InputStream)`은 삭제됨
- `Loader.loadPDF(byte[])`만 지원하므로 `file.getBytes()`로 바이트 배열을 먼저 얻어서 전달
- 불필요한 InputStream 변수와 주석 처리된 코드 정리

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
