### PR TITLE
fix: InterviewQna 생성 시 questionContent, answerContent null 필드 초기화

### DIFF
--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -106,6 +106,8 @@ public class InterviewService {
         InterviewQna firstTurn = InterviewQna.builder()
                 .interview(interview)
                 .sequenceNumber(1)
+                .questionContent("")
+                .answerContent("")
                 .startedAt(now)
                 .expiresAt(now.plusSeconds(ANSWER_TIME_LIMIT_SECONDS))
                 .build();
@@ -144,6 +146,8 @@ public class InterviewService {
         InterviewQna nextQna = InterviewQna.builder()
                 .interview(interview)
                 .sequenceNumber(nextTurnNumber)
+                .questionContent("")
+                .answerContent("")
                 .startedAt(now)
                 .expiresAt(expiresAt)
                 .build();


### PR DESCRIPTION
## 변경 사항
- `InterviewService`에서 `InterviewQna` 빌더 생성 시 `questionContent`와 `answerContent`를 빈 문자열(`""`)로 초기화
- 첫 번째 턴(firstTurn) 및 다음 턴(nextQna) 생성 로직 모두 적용

## 접근 방식
- 기존에는 두 필드가 `null`로 저장되어 면접 진행 중 NPE 또는 DB not-null 제약 위반이 발생할 수 있었음
- 빌더에 `.questionContent("").answerContent("")`를 명시적으로 추가하여 초기값 보장