### PR TITLE
fix: CORS 허용 출처를 환경변수로 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,9 @@ LIVEKIT_API_SECRET=
 # Agent 쪽 .env 와 동일한 값을 설정해야 합니다.
 # 생성 예시: openssl rand -base64 32
 INTERNAL_SERVICE_TOKEN=change-me-to-a-shared-secret
+
+# --- CORS ---
+# 허용할 프론트엔드 출처 (쉼표로 구분).
+# 로컬 개발: http://localhost:5173,http://localhost:5174
+# 프로덕션: 실제 프론트 배포 도메인으로 교체
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174

--- a/src/main/java/com/capstone/interview/config/WebConfig.java
+++ b/src/main/java/com/capstone/interview/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.capstone.interview.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -8,6 +9,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed-origins}")
+    private String[] allowedOrigins;
 
     @Bean
     public ObjectMapper objectMapper() {
@@ -17,7 +21,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+                .allowedOrigins(allowedOrigins)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,6 @@ jwt:
 
 internal:
   service-token: ${INTERNAL_SERVICE_TOKEN:default-dev-token}
+
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:5174}


### PR DESCRIPTION
## 변경 이유
로컬에서 프론트(`localhost:5173`, `5174`)를 실행해 배포된 백엔드 서버에 연결할 때 CORS 에러 발생.
기존 코드에 `allowedHeaders`가 없어 JWT 등 커스텀 헤더가 preflight에서 차단됨.

## 변경 내용
- `WebConfig`: `allowedOrigins`를 환경변수 `CORS_ALLOWED_ORIGINS`에서 읽도록 변경
- `application.yml`: `cors.allowed-origins` 설정 추가 (기본값: `localhost:5173, 5174`)
- `allowedHeaders("*")`, `allowCredentials(true)` 추가
- `.env.example`: `CORS_ALLOWED_ORIGINS` 항목 문서화

## EC2 .env에 추가 필요
```
CORS_ALLOWED_ORIGINS=https://capstonefront.vercel.app,http://localhost:5173,http://localhost:5174
```
추가 후 서버 재시작 필요.