### PR TITLE
fix: resumes.keywords 컬럼 타입 json → text 변경

### DIFF
--- a/src/main/java/com/capstone/interview/entity/Resume.java
+++ b/src/main/java/com/capstone/interview/entity/Resume.java
@@ -30,8 +30,7 @@ public class Resume {
     @Column(name = "file_url", length = 1024)
     private String fileUrl;
 
-    // JSON 타입 — 실제 파싱/직렬화는 서비스 레이어에서 처리
-    @Column(columnDefinition = "json")
+    @Column(columnDefinition = "text")
     private String keywords;
 
     // TODO: pgvector 타입 지원 시 vector(1536)으로 교체 (현재 JPA 기본 미지원)


### PR DESCRIPTION
## 문제
이력서 업로드 시 500 INTERNAL_ERROR 발생.

## 원인
PostgreSQL `json` 타입 컬럼에 Java `String`(varchar) 값을 직접 삽입하면 타입 불일치 오류 발생.
```
column "keywords" is of type json but expression is of type character varying
```

## 수정
- RDS DB: `ALTER TABLE resumes ALTER COLUMN keywords TYPE text`
- 엔티티: `@Column(columnDefinition = "json")` → `@Column(columnDefinition = "text")`

## 검증
- POST /v1/resumes/upload-text → 201 ✅
- GET /v1/resumes → 200 ✅

Made with [Cursor](https://cursor.com)