### PR TITLE
fix: PDF 업로드 파일 크기 제한 10MB로 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}


### PR DESCRIPTION
## 관련 Issue
- closes #이슈번호

## 변경 사항
- application.yml에 multipart 파일 크기 제한 설정 추가
- Spring Boot 기본값(1MB)으로 인해 큰 PDF 이력서 업로드 시 에러 발생하던 문제 해결

## 접근 방식
- spring.servlet.multipart.max-file-size와 max-request-size를 10MB로 설정
- 이력서 PDF는 보통 수백KB~수MB이므로 10MB면 충분

## 테스트
- 어떻게 테스트했는지 (스크린샷, 실행 결과 등)

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
