### PR TITLE
[Feature] interview_qnas 답변 분석 필드 저장

### DIFF
--- a/design.md
+++ b/design.md
@@ -335,6 +335,9 @@ erDiagram
         text answer_content
         boolean is_follow_up
         bigint parent_id FK
+        text answer_summary
+        varchar follow_up_decision
+        text focus_point
         text model_answer
         text individual_feedback
         varchar audio_url
@@ -379,6 +382,9 @@ erDiagram
 - 면접 내 각 질문-답변 쌍
 - `is_follow_up`: 꼬리질문 여부
 - `parent_id`: 꼬리질문인 경우 부모 질문 ID (셀프 참조)
+- `answer_summary`: Agent가 답변 요약 AI로 추출한 핵심 주장 목록(JSON 문자열)
+- `follow_up_decision`: 답변 판단 결과 (`FOLLOW_UP` / `NEXT_QUESTION`)
+- `focus_point`: `FOLLOW_UP` 판단 시 꼬리질문 생성 방향 힌트
 - `model_answer`: LLM이 생성한 모범 답안
 - `individual_feedback`: 해당 질문-답변에 대한 개별 피드백
 - `audio_url`: S3에 저장된 답변 오디오 파일 주소
@@ -448,6 +454,9 @@ CREATE TABLE interview_qnas (
     answer_content TEXT,                                        -- 답변은 나중에 채워짐
     is_follow_up BOOLEAN NOT NULL DEFAULT FALSE,
     parent_id BIGINT REFERENCES interview_qnas(id),
+    answer_summary TEXT,                                        -- Agent answerSummary(JSON string)
+    follow_up_decision VARCHAR(32),                             -- FOLLOW_UP / NEXT_QUESTION
+    focus_point TEXT,                                           -- FOLLOW_UP 판단 시 꼬리질문 방향
     model_answer TEXT,                                          -- 면접 종료 후 LLM 생성
     individual_feedback TEXT,                                   -- 면접 종료 후 LLM 생성
     audio_url VARCHAR(1024),

--- a/scripts/add-qna-analysis-columns.sql
+++ b/scripts/add-qna-analysis-columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE interview_qnas
+  ADD COLUMN IF NOT EXISTS answer_summary TEXT NULL,
+  ADD COLUMN IF NOT EXISTS follow_up_decision VARCHAR(32) NULL,
+  ADD COLUMN IF NOT EXISTS focus_point TEXT NULL;

--- a/src/main/java/com/capstone/interview/dto/InternalQnaRequest.java
+++ b/src/main/java/com/capstone/interview/dto/InternalQnaRequest.java
@@ -1,9 +1,14 @@
 package com.capstone.interview.dto;
 
+import java.util.List;
+
 public record InternalQnaRequest(
     Integer turnNumber,
     String question,
     String intent,
     Boolean isFollowUp,
-    String answer
+    String answer,
+    List<String> answerSummary,
+    String followUpDecision,
+    String focusPoint
 ) {}

--- a/src/main/java/com/capstone/interview/entity/InterviewQna.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewQna.java
@@ -47,6 +47,15 @@ public class InterviewQna {
     @Column(name = "individual_feedback", columnDefinition = "TEXT")
     private String individualFeedback;
 
+    @Column(name = "answer_summary", columnDefinition = "TEXT")
+    private String answerSummary;
+
+    @Column(name = "follow_up_decision", length = 32)
+    private String followUpDecision;
+
+    @Column(name = "focus_point", columnDefinition = "TEXT")
+    private String focusPoint;
+
     @Column(name = "audio_url", length = 1024)
     private String audioUrl;
 
@@ -70,7 +79,8 @@ public class InterviewQna {
     @Builder
     public InterviewQna(Interview interview, Integer sequenceNumber, String questionContent,
                         String answerContent, boolean isFollowUp, InterviewQna parent,
-                        String intent, LocalDateTime startedAt, LocalDateTime expiresAt) {
+                        String intent, String answerSummary, String followUpDecision,
+                        String focusPoint, LocalDateTime startedAt, LocalDateTime expiresAt) {
         this.interview = interview;
         this.sequenceNumber = sequenceNumber;
         this.questionContent = questionContent;
@@ -78,6 +88,9 @@ public class InterviewQna {
         this.isFollowUp = isFollowUp;
         this.parent = parent;
         this.intent = intent;
+        this.answerSummary = answerSummary;
+        this.followUpDecision = followUpDecision;
+        this.focusPoint = focusPoint;
         this.startedAt = startedAt;
         this.expiresAt = expiresAt;
     }
@@ -90,6 +103,12 @@ public class InterviewQna {
         this.questionContent = questionContent;
         this.intent = intent;
         this.isFollowUp = isFollowUp;
+    }
+
+    public void updateAnswerAnalysis(String answerSummary, String followUpDecision, String focusPoint) {
+        this.answerSummary = answerSummary;
+        this.followUpDecision = followUpDecision;
+        this.focusPoint = focusPoint;
     }
 
     public void updateTimer(LocalDateTime startedAt, LocalDateTime expiresAt) {

--- a/src/main/java/com/capstone/interview/service/InternalQnaService.java
+++ b/src/main/java/com/capstone/interview/service/InternalQnaService.java
@@ -1,5 +1,7 @@
 package com.capstone.interview.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.capstone.interview.dto.InternalQnaRequest;
 import com.capstone.interview.entity.Interview;
 import com.capstone.interview.entity.InterviewQna;
@@ -18,6 +20,7 @@ public class InternalQnaService {
 
     private final InterviewRepository interviewRepository;
     private final InterviewQnaRepository interviewQnaRepository;
+    private final ObjectMapper objectMapper;
 
     /**
      * Agent 가 매 턴 전송하는 Q+A 를 upsert 한다.
@@ -45,6 +48,19 @@ public class InternalQnaService {
             if (request.answer() != null) {
                 existing.updateAnswer(request.answer());
             }
+            if (hasAnswerAnalysis(request)) {
+                existing.updateAnswerAnalysis(
+                        request.answerSummary() != null
+                                ? toJson(request.answerSummary())
+                                : existing.getAnswerSummary(),
+                        request.followUpDecision() != null
+                                ? request.followUpDecision()
+                                : existing.getFollowUpDecision(),
+                        request.focusPoint() != null
+                                ? request.focusPoint()
+                                : existing.getFocusPoint()
+                );
+            }
             log.info("[QnA upsert] 기존 턴 업데이트. sessionId={}, turn={}", sessionId, request.turnNumber());
         } else {
             // insert: 새 레코드 생성
@@ -55,9 +71,29 @@ public class InternalQnaService {
                     .answerContent(request.answer() != null ? request.answer() : "")
                     .isFollowUp(request.isFollowUp() != null && request.isFollowUp())
                     .intent(request.intent())
+                    .answerSummary(toJson(request.answerSummary()))
+                    .followUpDecision(request.followUpDecision())
+                    .focusPoint(request.focusPoint())
                     .build();
             interviewQnaRepository.save(newQna);
             log.info("[QnA insert] 새 턴 저장. sessionId={}, turn={}", sessionId, request.turnNumber());
+        }
+    }
+
+    private boolean hasAnswerAnalysis(InternalQnaRequest request) {
+        return request.answerSummary() != null
+                || request.followUpDecision() != null
+                || request.focusPoint() != null;
+    }
+
+    private String toJson(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("answerSummary JSON serialization failed", e);
         }
     }
 }


### PR DESCRIPTION
﻿## 변경 사항

### 기능 변경
- Agent가 전송하는 QnA payload 확장 필드 수용
  - `answerSummary` (List<String>)
  - `followUpDecision` (`FOLLOW_UP` / `NEXT_QUESTION`)
  - `focusPoint`
- 내부 QnA upsert 저장 로직에 분석 필드 반영
  - 기존 턴 update 시 null-safe 병합 적용
  - 신규 insert 시 분석 필드 함께 저장
- `interview_qnas` 스키마 확장용 SQL 추가
  - `answer_summary` (TEXT)
  - `follow_up_decision` (VARCHAR(32))
  - `focus_point` (TEXT)

### 문서 변경
- `design.md`의 ER/엔티티 설명/DDL에 신규 컬럼 반영

## 코드 변경
- `InternalQnaRequest` 필드 확장
- `InterviewQna` 엔티티 컬럼 + 업데이트 메서드 추가
- `InternalQnaService`에 분석 필드 직렬화/저장 로직 추가
- `scripts/add-qna-analysis-columns.sql` 추가
- `design.md` 스키마 문서 업데이트

## 접근 방식
- `answerSummary`는 구조를 유지하기 위해 DB에는 JSON 문자열(TEXT)로 저장
- 기존/구버전 Agent와의 호환성을 위해 신규 필드는 optional 처리
- 업데이트 시 분석 필드가 일부만 와도 기존 값이 사라지지 않도록 null-safe merge 적용

## 테스트
- `./gradlew.bat compileJava` BUILD SUCCESSFUL

## 운영 반영 순서
1. RDS에 `scripts/add-qna-analysis-columns.sql` 실행
2. Backend 배포
3. RAG 배포
