### PR TITLE
[Fix] PDF 텍스트 추출 시 NULL 바이트로 인한 PostgreSQL UTF8 오류 수정

### DIFF
--- a/src/main/java/com/capstone/interview/service/PdfParserService.java
+++ b/src/main/java/com/capstone/interview/service/PdfParserService.java
@@ -32,8 +32,9 @@ public class PdfParserService {
             PDFTextStripper stripper = new PDFTextStripper();
             String text = stripper.getText(document);
 
-            log.info("[PDF 파싱] 완료: {}페이지, {}글자", document.getNumberOfPages(), text.length());
-            return text.trim();
+            String cleanedText = text.replace("\u0000", "");
+            log.info("[PDF 파싱] 완료: {}페이지, {}글자", document.getNumberOfPages(), cleanedText.length());
+            return cleanedText.trim();
         }
     }
 }


### PR DESCRIPTION
## 관련 Issue
- closes #

## 문제 상황
- 마이페이지에서 PDF 이력서 업로드 시 서버 오류로 업로드가 실패하는 현상 발생
  - 에러 발생 시각: 2026-05-17 15:59:20, 16:04:45 (동일 오류 2회)
  - 업로드 파일: `김준범_이력서.pdf` (560,067 bytes, 3페이지)

## 변경 사항
- `PdfParserService.extractText()`에서 텍스트 추출 후 NULL 바이트(`\u0000`) 제거 처리 추가
  - PDFBox가 특정 PDF(임베디드 폰트, 폼 필드 포함)에서 `\u0000`을 포함한 텍스트를 반환하는 경우가 있음
  - PostgreSQL UTF-8 인코딩은 `\x00`을 허용하지 않아 `DataIntegrityViolationException` 발생
  - `resumeRepository.save()` 호출 전 `cleanedText.replace("\u0000", "")` 적용으로 해결

## 접근 방식
- 수정 위치는 `PdfParserService`(소스)로 선택 — `ResumeService`에서 제거하는 것보다 책임 분리 측면에서 적합
- 단순 문자열 치환으로 해결, 별도 의존성 추가 없음

## AI 사용 내역
- 에러 재현 가능성 판단 및 수정 위치 결정에 AI 보조 사용
- 직접 확인한 부분: `PdfParserService.java` 코드 검토, 스택트레이스와 실제 코드 라인 매핑 확인

## 테스트
- `./gradlew.bat compileJava` BUILD SUCCESSFUL
- 에러 재현 조건: `김준범_이력서.pdf` (560,067 bytes, 3페이지) 업로드 시 `DataIntegrityViolationException` 발생 → 수정 후 해소

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
