### PR TITLE
[Fix] 피드백 결과 내 답변을 STT 원문 대신 답변 요약으로 표시

### DIFF
--- a/src/main/java/com/capstone/interview/service/FeedbackService.java
+++ b/src/main/java/com/capstone/interview/service/FeedbackService.java
@@ -7,6 +7,8 @@ import com.capstone.interview.entity.InterviewQna;
 import com.capstone.interview.entity.InterviewStatus;
 import com.capstone.interview.repository.InterviewQnaRepository;
 import com.capstone.interview.repository.InterviewRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ public class FeedbackService {
     private final InterviewRepository interviewRepository;
     private final InterviewQnaRepository interviewQnaRepository;
     private final MemberRepository memberRepository;
+    private final ObjectMapper objectMapper;
 
 
     /**
@@ -53,7 +56,7 @@ public class FeedbackService {
                 .map(qna -> QAPair.builder()
                         .sequenceNumber(qna.getSequenceNumber())
                         .questionContent(qna.getQuestionContent())
-                        .answerContent(qna.getAnswerContent())
+                        .answerContent(parseAnswerSummary(qna))
                         .modelAnswer(qna.getModelAnswer())
                         .individualFeedback(qna.getIndividualFeedback())
                         .isFollowUp(qna.isFollowUp()) // 엔티티의 메서드 사용
@@ -109,6 +112,31 @@ public class FeedbackService {
             return rawData.substring(rawData.indexOf("[CHART]") + "[CHART]".length()).trim();
         }
         return "{}";
+    }
+
+    /**
+     * answerSummary(JSON 배열)를 파싱해 줄바꿈으로 이어붙인 문자열을 반환한다.
+     * answerSummary가 없으면 answerContent(STT 원문)로 폴백한다.
+     */
+    private String parseAnswerSummary(InterviewQna qna) {
+        String summary = qna.getAnswerSummary();
+        if (summary == null || summary.isBlank()) {
+            return qna.getAnswerContent();
+        }
+        try {
+            JsonNode node = objectMapper.readTree(summary);
+            if (node.isArray()) {
+                StringBuilder sb = new StringBuilder();
+                for (JsonNode item : node) {
+                    if (sb.length() > 0) sb.append("\n");
+                    sb.append(item.asText());
+                }
+                return sb.toString();
+            }
+            return summary;
+        } catch (Exception e) {
+            return summary;
+        }
     }
 
     /*


### PR DESCRIPTION
## 관련 Issue
- 피드백 화면에서 '내 답변' 항목에 STT 원문 전체가 노출되는 문제

## 변경 사항
- FeedbackService에서 QAPair 변환 시 answerContent(STT 원문) 대신 answerSummary(에이전트 요약)를 사용하도록 수정
- answerSummary가 null 또는 blank인 경우 answerContent로 폴백 처리 유지

## 접근 방식
- ObjectMapper를 FeedbackService에 주입하여 answerSummary(JSON 배열 문자열)를 파싱
- 배열 요소를 줄바꿈(\n)으로 이어붙여 가독성 있는 문자열로 변환
- parseAnswerSummary() 헬퍼 메서드를 통해 로직 분리

## AI 사용 내역
- 어떤 부분에 AI를 사용했는지: 코드 수정 및 PR 작성 전반
- 직접 확인하고 수정한 부분: git diff로 변경사항 검증, 폴백 로직 설계

## 테스트
- answerSummary가 있는 경우: JSON 배열 파싱 후 줄바꿈 결합 값 반환 확인
- answerSummary가 null인 경우: answerContent(STT 원문) 폴백 반환 확인

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가