### PR TITLE
[Fix] LLM 평가 프롬프트에 STT 원문 대신 답변 요약 사용

### DIFF
--- a/src/main/java/com/capstone/interview/service/EvaluationService.java
+++ b/src/main/java/com/capstone/interview/service/EvaluationService.java
@@ -87,7 +87,7 @@ public class EvaluationService {
             sb.append("[질문 %d] %s\n".formatted(qna.getSequenceNumber(), qna.getQuestionContent()));
             sb.append("[답변 %d] %s\n\n".formatted(
                     qna.getSequenceNumber(),
-                    qna.getAnswerContent() != null ? qna.getAnswerContent() : "답변 없음"
+                    parseAnswerSummary(qna)
             ));
         }
 
@@ -157,6 +157,31 @@ public class EvaluationService {
                     (llmResponse != null && llmResponse.length() > 200) ? llmResponse.substring(0, 200) : llmResponse, e);
             interview.fail();
             interviewRepository.save(interview);
+        }
+    }
+
+    /**
+     * answerSummary(JSON 배열)를 파싱해 줄바꿈으로 이어붙인 문자열을 반환한다.
+     * answerSummary가 없으면 answerContent(STT 원문)로 폴백한다.
+     */
+    private String parseAnswerSummary(InterviewQna qna) {
+        String summary = qna.getAnswerSummary();
+        if (summary == null || summary.isBlank()) {
+            return qna.getAnswerContent() != null ? qna.getAnswerContent() : "답변 없음";
+        }
+        try {
+            JsonNode node = objectMapper.readTree(summary);
+            if (node.isArray()) {
+                StringBuilder sb = new StringBuilder();
+                for (JsonNode item : node) {
+                    if (sb.length() > 0) sb.append("\n");
+                    sb.append(item.asText());
+                }
+                return sb.isEmpty() ? (qna.getAnswerContent() != null ? qna.getAnswerContent() : "답변 없음") : sb.toString();
+            }
+            return summary;
+        } catch (Exception e) {
+            return qna.getAnswerContent() != null ? qna.getAnswerContent() : "답변 없음";
         }
     }
 


### PR DESCRIPTION
## 관련 Issue
- 모범답안/피드백이 정제되지 않은 STT 원문 기반으로 생성되어 품질이 낮은 문제

## 변경 사항
- EvaluationService.buildPrompt()에서 qna.getAnswerContent()(STT 원문) 대신 answerSummary 파싱 값을 LLM 프롬프트에 전달
- answerSummary가 null/blank인 경우 answerContent로 폴백 처리

## 접근 방식
- parseAnswerSummary() 헬퍼 메서드 추가 (FeedbackService의 동일 로직과 일관성 유지)
- answerSummary는 에이전트가 STT 원문을 정제한 JSON 배열로, LLM 평가에 적합한 데이터
- 직접 answerContent를 쓰던 기존 방식은 긴 STT 원문으로 인해 LLM 응답 품질 저하 유발

## AI 사용 내역
- 어떤 부분에 AI를 사용했는지: 코드 수정 및 PR 작성 전반
- 직접 확인하고 수정한 부분: git diff로 변경사항 검증, 폴백 로직 일관성 확인

## 테스트
- answerSummary가 있는 경우: 파싱된 요약이 LLM 프롬프트에 전달됨을 확인
- answerSummary가 null인 경우: answerContent(STT 원문)로 폴백됨을 확인

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가