### PR TITLE
[Fix] EvaluationService 테스트용 더미 QnA 삽입 블록 제거

### DIFF
--- a/src/main/java/com/capstone/interview/service/EvaluationService.java
+++ b/src/main/java/com/capstone/interview/service/EvaluationService.java
@@ -50,19 +50,10 @@ public class EvaluationService {
         List<InterviewQna> qnas = interviewQnaRepository
                 .findByInterviewOrderBySequenceNumberAsc(interview);
 
-        // ===== [TEST] 더미 QnA 생성 (실제 배포 시 이 블록 삭제하고 아래 원본 코드 주석 해제) =====
         if (qnas.isEmpty()) {
-            log.info("[TEST] 질문-답변 데이터가 없어 더미 데이터를 생성합니다. sessionId: {}", sessionId);
-            insertDummyQnas(interview);
-            qnas = interviewQnaRepository.findByInterviewOrderBySequenceNumberAsc(interview);
+            log.warn("질문-답변 데이터가 없습니다. sessionId: {}", sessionId);
+            return;
         }
-        
-        // ===== [TEST] 여기까지 삭제 =====
-        //[원본 코드] 실제 운영 시 아래 주석 해제
-        //if (qnas.isEmpty()) {
-        //    log.warn("질문-답변 데이터가 없습니다. sessionId: {}", sessionId);
-        //    return;
-        //}
 
         // 3. LLM에게 평가 요청
         String prompt = buildPrompt(interview, qnas);
@@ -173,26 +164,4 @@ public class EvaluationService {
         return response;
     }
 
-       
-    /**
-     * 테스트용: QnA 데이터가 없을 때 더미 질문-답변을 생성한다.
-     * 실제 운영 시 제거할 것.
-     */
-    private void insertDummyQnas(Interview interview) {
-        List<InterviewQna> dummies = List.of(
-                InterviewQna.createDummy(interview, 1,
-                        "Spring에서 DI(의존성 주입)란 무엇인가요?",
-                        "객체가 필요한 의존성을 외부에서 주입받는 패턴입니다. Spring에서는 @Autowired나 생성자 주입을 통해 구현합니다.",
-                        false),
-                InterviewQna.createDummy(interview, 2,
-                        "생성자 주입을 권장하는 이유는 무엇인가요?",
-                        "생성자 주입은 final 키워드를 사용할 수 있어 불변성을 보장하고, 테스트 시 Mock 객체를 쉽게 주입할 수 있기 때문입니다.",
-                        true),
-                InterviewQna.createDummy(interview, 3,
-                        "JPA에서 N+1 문제가 무엇이고 어떻게 해결하나요?",
-                        "연관 엔티티를 지연 로딩할 때 추가 쿼리가 N번 발생하는 문제입니다. fetch join이나 @EntityGraph로 해결합니다.",
-                        false)
-        );
-        interviewQnaRepository.saveAll(dummies);
-    }
 }


### PR DESCRIPTION
## 관련 Issue
- EvaluationService에 개발 편의용 테스트 코드가 잔존하여 운영 환경에서 엉뚱한 Spring DI 더미 질문으로 평가가 이루어질 위험

## 변경 사항
- QnA 데이터가 없을 때 더미 질문-답변(Spring DI, 생성자 주입, N+1 등)을 삽입하던 TEST 블록 제거
- 주석 처리되어 있던 원본 방어 코드(isEmpty 시 warn 로그 후 return) 복원
- insertDummyQnas() 메서드 제거

## 접근 방식
- 현재는 InterviewService.createSession()에서 첫 턴 레코드를 미리 생성하므로 isEmpty() 조건은 실제로 거의 타지 않음
- 그럼에도 TEST 코드 잔존은 잠재적 데이터 오염 위험이므로 완전 제거
- 원본 의도대로 QnA 없으면 warn 로그만 남기고 평가 중단 처리

## AI 사용 내역
- 어떤 부분에 AI를 사용했는지: 코드 수정 및 PR 작성 전반
- 직접 확인하고 수정한 부분: git diff로 변경사항 검증, 원본 방어 코드 복원 확인

## 테스트
- QnA 데이터가 있는 경우: 기존과 동일하게 LLM 평가 진행
- QnA 데이터가 없는 경우: warn 로그 출력 후 평가 없이 종료(더미 삽입 없음)

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가