### PR TITLE
[Feature] 턴별 피드백 평가 흐름 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
+	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	//AWS 베드락 의존성 추가
 	implementation platform('software.amazon.awssdk:bom:2.25.11')

--- a/src/main/java/com/capstone/interview/config/BedrockConfig.java
+++ b/src/main/java/com/capstone/interview/config/BedrockConfig.java
@@ -1,0 +1,22 @@
+package com.capstone.interview.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+
+@Configuration
+@ConditionalOnProperty(name = "llm.provider", havingValue = "bedrock")
+public class BedrockConfig {
+
+    @Bean
+    public BedrockRuntimeClient bedrockRuntimeClient(
+            @Value("${llm.bedrock.region:us-east-1}") String region
+    ) {
+        return BedrockRuntimeClient.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/interview/config/BedrockLLMClient.java
+++ b/src/main/java/com/capstone/interview/config/BedrockLLMClient.java
@@ -1,0 +1,79 @@
+package com.capstone.interview.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bedrock Claude client for interview evaluation prompts.
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "llm.provider", havingValue = "bedrock")
+public class BedrockLLMClient implements LLMClient {
+
+    private final BedrockRuntimeClient bedrockRuntimeClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${llm.bedrock.model-id:us.anthropic.claude-sonnet-4-6}")
+    private String modelId;
+
+    @Value("${llm.bedrock.max-tokens:1200}")
+    private int maxTokens;
+
+    @Value("${llm.bedrock.temperature:0.2}")
+    private double temperature;
+
+    @Override
+    public String invoke(String prompt) {
+        return invoke("", prompt);
+    }
+
+    @Override
+    public String invoke(String systemPrompt, String userPrompt) {
+        try {
+            Map<String, Object> body = Map.of(
+                    "anthropic_version", "bedrock-2023-05-31",
+                    "max_tokens", maxTokens,
+                    "temperature", temperature,
+                    "system", systemPrompt == null ? "" : systemPrompt,
+                    "messages", List.of(Map.of(
+                            "role", "user",
+                            "content", List.of(Map.of(
+                                    "type", "text",
+                                    "text", userPrompt == null ? "" : userPrompt
+                            ))
+                    ))
+            );
+
+            InvokeModelRequest request = InvokeModelRequest.builder()
+                    .modelId(modelId)
+                    .contentType("application/json")
+                    .accept("application/json")
+                    .body(SdkBytes.fromUtf8String(objectMapper.writeValueAsString(body)))
+                    .build();
+
+            InvokeModelResponse response = bedrockRuntimeClient.invokeModel(request);
+            JsonNode root = objectMapper.readTree(response.body().asUtf8String());
+            return root.path("content").path(0).path("text").asText();
+        } catch (Exception e) {
+            throw new IllegalStateException("Bedrock LLM invocation failed", e);
+        }
+    }
+
+    @Override
+    public List<Float> embed(String text) {
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/com/capstone/interview/config/LLMClient.java
+++ b/src/main/java/com/capstone/interview/config/LLMClient.java
@@ -3,16 +3,23 @@ package com.capstone.interview.config;
 import java.util.List;
 
 /**
- * LLM 호출 공통 인터페이스.
- * 모든 LLM 호출 모듈(ResumeService, QuestionGenerator, FollowUpEngine, AnswerEvaluator)은
- * 이 인터페이스를 통해 LLM에 접근한다.
- * 구현체 예시: BedrockClaudeClient, BedrockTitanClient
+ * Common interface for LLM calls.
  */
 public interface LLMClient {
 
-    /** 프롬프트를 보내고 텍스트 응답을 받는다 */
+    /** Sends a single prompt and returns a text response. */
     String invoke(String prompt);
 
-    /** 텍스트를 임베딩 벡터로 변환한다 (RAG 파이프라인용) */
+    /**
+     * Sends stable instructions separately from per-request input.
+     */
+    default String invoke(String systemPrompt, String userPrompt) {
+        if (systemPrompt == null || systemPrompt.isBlank()) {
+            return invoke(userPrompt);
+        }
+        return invoke(systemPrompt + "\n\n" + userPrompt);
+    }
+
+    /** Converts text into an embedding vector. */
     List<Float> embed(String text);
 }

--- a/src/main/java/com/capstone/interview/config/MockLLMClient.java
+++ b/src/main/java/com/capstone/interview/config/MockLLMClient.java
@@ -1,48 +1,48 @@
 package com.capstone.interview.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+
 import java.util.List;
 
 /**
- * Bedrock 키 없을 때 테스트용 가짜 LLM 클라이언트
- * 실제 Bedrock 연동 시 BedrockLLMClient로 교체
+ * Local/test LLM client that returns schema-compatible JSON without Bedrock.
  */
 @Component
+@ConditionalOnProperty(name = "llm.provider", havingValue = "mock", matchIfMissing = true)
 public class MockLLMClient implements LLMClient {
 
     @Override
     public String invoke(String prompt) {
+        return invoke("", prompt);
+    }
+
+    @Override
+    public String invoke(String systemPrompt, String userPrompt) {
+        String merged = ((systemPrompt == null ? "" : systemPrompt) + "\n" + (userPrompt == null ? "" : userPrompt))
+                .toLowerCase();
+
+        if (merged.contains("total_feedback") || merged.contains("competency_chart")) {
+            return """
+                    {
+                      "total_feedback": "전반적으로 핵심 개념을 이해하고 답변하려는 흐름이 좋았습니다. 다만 일부 답변은 내부 동작 원리와 구체적 경험 연결이 부족해 깊이가 아쉬웠습니다. 앞으로는 개념의 원리, 적용 상황, 트레이드오프를 함께 정리하면 더 설득력 있는 면접 답변이 됩니다.",
+                      "overall_score": "중",
+                      "competency_chart": {
+                        "기술역량": 7,
+                        "문제해결력": 6,
+                        "논리적 설명력": 7,
+                        "직무적합성": 6
+                      }
+                    }
+                    """;
+        }
+
         return """
-            {
-              "individual_feedbacks": [
                 {
-                  "sequence_number": 1,
-                  "question_type": "기술역량",
-                  "individual_feedback": "DI 개념을 정확히 이해하고 있으며, @Autowired와 생성자 주입을 언급한 점이 좋습니다. 다만 DI 컨테이너의 동작 원리까지 설명했으면 더 좋았을 것입니다.",
-                  "model_answer": "의존성 주입(DI)은 객체가 필요로 하는 의존 객체를 직접 생성하지 않고, 외부(스프링 컨테이너)에서 생성하여 주입해주는 디자인 패턴입니다. 이를 통해 결합도를 낮추고 테스트 용이성을 높일 수 있습니다. Spring에서는 @Autowired, 생성자 주입, setter 주입 방식을 지원합니다."
-                },
-                {
-                  "sequence_number": 2,
-                  "question_type": "기술역량",
-                  "individual_feedback": "생성자 주입의 불변성과 테스트 용이성을 정확히 짚었습니다. 필드 주입의 순환 참조 문제나 Spring 팀의 공식 권장 사항까지 언급하면 더 완성도 높은 답변이 됩니다.",
-                  "model_answer": "생성자 주입은 final 필드를 사용하여 불변성을 보장하고, 의존성이 명시적이어서 테스트 시 Mock 객체를 쉽게 주입할 수 있습니다. 필드 주입은 코드가 간결하지만 리플렉션에 의존하고, 순환 참조를 컴파일 타임에 감지할 수 없습니다. Spring 공식 문서에서도 생성자 주입을 권장합니다."
-                },
-                {
-                  "sequence_number": 3,
-                  "question_type": "문제해결력",
-                  "individual_feedback": "fetch join과 @EntityGraph를 정확히 언급했습니다. 추가로 Batch Size 설정이나 DTO 프로젝션 등 상황별 해결 전략을 비교 설명하면 더 깊이 있는 답변이 됩니다.",
-                  "model_answer": "N+1 문제는 연관 엔티티를 지연 로딩할 때 추가 쿼리가 N번 발생하는 현상입니다. 해결 방법으로는 (1) JPQL fetch join으로 한 번에 조회, (2) @EntityGraph로 연관 엔티티 즉시 로딩, (3) hibernate.default_batch_fetch_size 설정으로 IN 절 배치 처리, (4) DTO 프로젝션으로 필요한 데이터만 조회하는 방법이 있습니다."
+                  "individual_feedback": "핵심 개념은 잘 짚었지만, 동작 원리와 실제 적용 경험을 함께 설명하면 더 설득력 있는 답변이 됩니다.",
+                  "model_answer": "이 질문에는 개념 정의를 먼저 말하고, 동작 방식과 사용 이유를 간단히 설명한 뒤 프로젝트에서 적용한 사례나 트레이드오프를 덧붙이면 좋습니다."
                 }
-              ],
-              "total_feedback": "전반적으로 Spring 핵심 개념에 대한 이해도가 높은 면접이었습니다. DI와 JPA 관련 질문에 핵심을 정확히 짚었으며, 실무 경험이 반영된 답변이 인상적입니다. 1)잘한점: 기술 개념의 핵심을 간결하게 전달하는 능력이 우수합니다. 2)부족한점: 답변의 깊이가 다소 얕아 심화 내용이 부족합니다. 3)개선방향: 각 기술의 내부 동작 원리와 트레이드오프를 학습하여 Why까지 설명할 수 있도록 준비하세요.",
-              "competency_chart": {
-                "기술역량": 8,
-                "문제해결력": 7,
-                "학습력": 6
-              },
-              "overall_score": "중"
-            }
-            """;
+                """;
     }
 
     @Override

--- a/src/main/java/com/capstone/interview/event/QnaSavedEvent.java
+++ b/src/main/java/com/capstone/interview/event/QnaSavedEvent.java
@@ -1,0 +1,7 @@
+package com.capstone.interview.event;
+
+public record QnaSavedEvent(
+        String sessionId,
+        Integer turnNumber
+) {
+}

--- a/src/main/java/com/capstone/interview/service/EvaluationService.java
+++ b/src/main/java/com/capstone/interview/service/EvaluationService.java
@@ -3,6 +3,7 @@ package com.capstone.interview.service;
 import com.capstone.interview.config.LLMClient;
 import com.capstone.interview.entity.Interview;
 import com.capstone.interview.entity.InterviewQna;
+import com.capstone.interview.event.QnaSavedEvent;
 import com.capstone.interview.repository.InterviewQnaRepository;
 import com.capstone.interview.repository.InterviewRepository;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -12,16 +13,73 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EvaluationService {
+
+    private static final String TURN_EVALUATION_SYSTEM_PROMPT = """
+            당신은 신입/주니어 개발자 기술 면접 답변을 평가하는 전문 면접관입니다.
+
+            평가 원칙:
+            - 질문 의도와 지원자 답변 요약의 일치도, 기술 정확성, 논리성, 구체성, 실무 연결성을 기준으로 평가합니다.
+            - 지나친 칭찬이나 혹평 없이, 실제 면접 후 피드백처럼 구체적이고 실용적으로 작성합니다.
+            - 모범답안은 암기식 정답이 아니라 면접에서 말하기 좋은 자연스러운 답변으로 작성합니다.
+            - 답변 요약이 비어 있거나 모름에 가까우면 부족한 점과 학습 방향을 짧게 제시합니다.
+
+            출력 규칙:
+            - 반드시 JSON 객체만 출력합니다.
+            - Markdown, 코드블록, 설명 문장, 주석을 출력하지 않습니다.
+            - individual_feedback은 120자 이하입니다.
+            - model_answer는 180자 이하입니다.
+            - 모든 문장은 한국어로 작성합니다.
+
+            출력 형식:
+            {
+              "individual_feedback": "답변에 대한 짧고 구체적인 피드백",
+              "model_answer": "면접에서 말하기 좋은 모범답안"
+            }
+            """;
+
+    private static final String TOTAL_EVALUATION_SYSTEM_PROMPT = """
+            당신은 신입/주니어 개발자 기술 면접 결과를 종합하는 전문 평가자입니다.
+
+            역할:
+            - 여러 턴의 질문, 답변 요약, 개별 피드백을 바탕으로 전체 면접 결과를 요약합니다.
+            - 원본 답변을 새로 길게 재평가하지 말고, 제공된 턴별 평가 결과를 종합합니다.
+            - 강점, 약점, 개선 방향이 명확히 드러나도록 작성합니다.
+
+            평가 기준:
+            - 기술역량: 개념 이해, 기술 정확성, 원리 설명 능력
+            - 문제해결력: 상황 분석, 해결 전략, 트러블슈팅 사고
+            - 논리적 설명력: 답변 구조, 근거 제시, 전달 명확성
+            - 직무적합성: 지원 직무와 답변 경험의 연결성
+
+            출력 규칙:
+            - 반드시 JSON 객체만 출력합니다.
+            - Markdown, 코드블록, 설명 문장, 주석을 출력하지 않습니다.
+            - total_feedback은 400자 이하입니다.
+            - overall_score는 반드시 "상", "중", "하" 중 하나입니다.
+            - competency_chart의 값은 0~10 사이 정수입니다.
+            - 모든 문장은 한국어로 작성합니다.
+
+            출력 형식:
+            {
+              "total_feedback": "전체 면접에 대한 종합 피드백",
+              "overall_score": "중",
+              "competency_chart": {
+                "기술역량": 0,
+                "문제해결력": 0,
+                "논리적 설명력": 0,
+                "직무적합성": 0
+              }
+            }
+            """;
 
     private final InterviewRepository interviewRepository;
     private final InterviewQnaRepository interviewQnaRepository;
@@ -29,155 +87,193 @@ public class EvaluationService {
     private final ObjectMapper objectMapper;
 
     @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleQnaSaved(QnaSavedEvent event) {
+        try {
+            evaluateTurn(event.sessionId(), event.turnNumber());
+        } catch (Exception e) {
+            log.warn("[turn evaluation failed] sessionId={}, turn={}", event.sessionId(), event.turnNumber(), e);
+        }
+    }
+
+    @Transactional
+    public void evaluateTurn(String sessionId, Integer turnNumber) {
+        Interview interview = interviewRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
+        InterviewQna qna = interviewQnaRepository.findByInterviewAndSequenceNumber(interview, turnNumber)
+                .orElseThrow(() -> new IllegalArgumentException("QnA를 찾을 수 없습니다: " + sessionId + "#" + turnNumber));
+
+        if (!shouldEvaluateTurn(qna)) {
+            return;
+        }
+
+        try {
+            String response = llmClient.invoke(
+                    TURN_EVALUATION_SYSTEM_PROMPT,
+                    buildTurnPrompt(interview, qna)
+            );
+            JsonNode root = objectMapper.readTree(extractJson(response));
+
+            String individualFeedback = root.path("individual_feedback").asText("");
+            String modelAnswer = root.path("model_answer").asText("");
+            qna.saveFeedback(modelAnswer, individualFeedback);
+            interviewQnaRepository.save(qna);
+
+            log.info("[turn evaluation saved] sessionId={}, turn={}", sessionId, turnNumber);
+        } catch (Exception e) {
+            throw new IllegalStateException("Turn evaluation failed: " + sessionId + "#" + turnNumber, e);
+        }
+    }
+
+    @Async
     @Transactional
     public void evaluate(String sessionId) {
-        // 1. sessionId로 면접 조회
+        waitForLastAgentSave();
+
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
 
-        // 중복 평가 방지
         if (interview.getTotalFeedback() != null) {
-            log.info("이미 평가 완료된 세션입니다: {}", sessionId);
+            log.info("[evaluation skipped] already completed sessionId={}", sessionId);
             return;
         }
 
-        // [방어 코드] 카테고리 정보가 없을 경우 처리
-        if (interview.getCategory() == null) {
-            log.warn("sessionId: {} 의 카테고리 정보가 없습니다. '일반'으로 진행합니다.", sessionId);
-        }
-
-        // 2. 해당 면접의 질문-답변 전체 조회
         List<InterviewQna> qnas = interviewQnaRepository
-                .findByInterviewOrderBySequenceNumberAsc(interview);
+                .findByInterviewOrderBySequenceNumberAsc(interview)
+                .stream()
+                .filter(this::hasQuestion)
+                .toList();
 
         if (qnas.isEmpty()) {
-            log.warn("질문-답변 데이터가 없습니다. sessionId: {}", sessionId);
+            log.warn("[evaluation skipped] no valid QnA sessionId={}", sessionId);
             return;
         }
 
-        // 3. LLM에게 평가 요청
-        String prompt = buildPrompt(interview, qnas);
-        String llmResponse = llmClient.invoke(prompt);
-
-        // 4. 응답 파싱 및 저장
-        parseAndSave(llmResponse, qnas, interview);
-    }
-
-    private String buildPrompt(Interview interview, List<InterviewQna> qnas) {
-        String category = (interview.getCategory() != null) ? interview.getCategory() : "일반 IT";
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("""
-                당신은 전문 면접관입니다.
-                아래는 %s 직무 면접의 전체 질문-답변 목록입니다.
-                각 질문의 유형을 [학습력/문제해결력/협업능력/기술역량/주도성/스트레스내성/직무적합성] 중 N개로 판단하고 평가해주세요.
-                
-                """.formatted(category));
-
         for (InterviewQna qna : qnas) {
-            sb.append("[질문 %d] %s\n".formatted(qna.getSequenceNumber(), qna.getQuestionContent()));
-            sb.append("[답변 %d] %s\n\n".formatted(
-                    qna.getSequenceNumber(),
-                    parseAnswerSummary(qna)
-            ));
+            if (shouldEvaluateTurn(qna)) {
+                evaluateTurn(sessionId, qna.getSequenceNumber());
+            }
         }
 
-        sb.append("""
-                아래 JSON 형식으로만 응답해주세요. JSON 외 다른 텍스트는 절대 포함하지 마세요.
-                
-                {
-                  "individual_feedbacks": [
-                    {
-                      "sequence_number": 1,
-                      "question_type": "[학습력/문제해결력/협업능력/기술역량/주도성/스트레스내성/직무 적합성] 7가지 유형 중 N개",
-                      "individual_feedback": "기술 정확도와 논리적 전달력 및 답변 구체성에 대한 평가 및 답변의 전반적인 강점/약점에 대해 3줄 이하로 서술.",
-                      "model_answer": "3줄 이내의 모범 답안"
-                    }
-                  ],
-                  "total_feedback": "나온 질문 유형들 중 강점 유형과 약점 유형을 언급하며, 1)잘한점 2)부족한점 3)개선방향을 포함하고, 준비도/전달력/지식불균형 분석과 핵심 학습 권고 3가지, 종합점수[상/중/하], 역량차트(나온 유형별 0~10점수)를 포함한 종합 피드백을 5줄 이하로 작성하세요.",
-                  "competency_chart": {
-                    "유형명": 점수
-                  },
-                  "overall_score": "상/중/하"
-                }
-                """);
+        String response = llmClient.invoke(
+                TOTAL_EVALUATION_SYSTEM_PROMPT,
+                buildTotalPrompt(interview, qnas)
+        );
+        parseAndSaveTotal(response, interview);
+    }
 
+    private String buildTurnPrompt(Interview interview, InterviewQna qna) {
+        return """
+                직무/카테고리:
+                %s
+
+                질문:
+                %s
+
+                질문 의도:
+                %s
+
+                꼬리질문 여부:
+                %s
+
+                지원자 답변 핵심 요약:
+                %s
+
+                부족하다고 판단된 지점:
+                %s
+                """.formatted(
+                valueOrDefault(interview.getCategory(), "일반 IT"),
+                valueOrDefault(qna.getQuestionContent(), "없음"),
+                valueOrDefault(qna.getIntent(), "없음"),
+                qna.isFollowUp(),
+                answerSummaryText(qna),
+                valueOrDefault(qna.getFocusPoint(), "없음")
+        );
+    }
+
+    private String buildTotalPrompt(Interview interview, List<InterviewQna> qnas) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("직무/카테고리:\n")
+                .append(valueOrDefault(interview.getCategory(), "일반 IT"))
+                .append("\n\n총 질문 수:\n")
+                .append(qnas.size())
+                .append("\n\n턴별 평가 결과:\n");
+
+        for (InterviewQna qna : qnas) {
+            sb.append(qna.getSequenceNumber()).append(".\n")
+                    .append("질문: ").append(valueOrDefault(qna.getQuestionContent(), "없음")).append('\n')
+                    .append("답변 요약: ").append(answerSummaryText(qna)).append('\n')
+                    .append("개별 피드백: ").append(valueOrDefault(qna.getIndividualFeedback(), "없음")).append("\n\n");
+        }
+
+        sb.append("위 턴별 평가 결과를 종합해 전체 피드백, 종합 등급, 역량 차트를 생성하세요.");
         return sb.toString();
     }
 
-    private void parseAndSave(String llmResponse, List<InterviewQna> qnas, Interview interview) {
+    private void parseAndSaveTotal(String llmResponse, Interview interview) {
         try {
-            String cleanedResponse = extractJson(llmResponse);
-            JsonNode root = objectMapper.readTree(cleanedResponse);
-
-            Map<Integer, InterviewQna> qnaMap = qnas.stream()
-                    .collect(Collectors.toMap(InterviewQna::getSequenceNumber, qna -> qna));
-
-            // 1. 개별 피드백 저장
-            List<InterviewQna> toUpdate = new ArrayList<>();
-            JsonNode individualFeedbacks = root.path("individual_feedbacks");
-            if (individualFeedbacks.isArray()) {
-                for (JsonNode feedbackNode : individualFeedbacks) {
-                    int seq = feedbackNode.path("sequence_number").asInt();
-                    String modelAns = feedbackNode.path("model_answer").asText("");
-                    String indFeedback = feedbackNode.path("individual_feedback").asText("");
-
-                    InterviewQna qna = qnaMap.get(seq);
-                    if (qna != null) {
-                        qna.saveFeedback(modelAns, indFeedback);
-                        toUpdate.add(qna);
-                    }
-                }
-            }
-            interviewQnaRepository.saveAll(toUpdate);
-
-            // 2. 종합 피드백 가공 저장
+            JsonNode root = objectMapper.readTree(extractJson(llmResponse));
             String totalFeedback = root.path("total_feedback").asText("피드백 정보가 없습니다.");
             String overallScore = root.path("overall_score").asText("N/A");
-            String competencyChart = root.path("competency_chart").toString();
+            String competencyChart = root.path("competency_chart").isMissingNode()
+                    ? "{}"
+                    : root.path("competency_chart").toString();
 
-            // 프론트 전달용 구분자 포함하여 결합
             String combined = totalFeedback + "\n\n[SCORE]\n" + overallScore + "\n\n[CHART]\n" + competencyChart;
-
             interview.saveTotalFeedback(combined);
             interviewRepository.save(interview);
-
+            log.info("[total evaluation saved] sessionId={}", interview.getSessionId());
         } catch (Exception e) {
-            log.error("파싱 실패. sessionId: {}, 응답 앞 200자: {}",
-                    interview.getSessionId(),
-                    (llmResponse != null && llmResponse.length() > 200) ? llmResponse.substring(0, 200) : llmResponse, e);
+            log.error("[total evaluation parse failed] sessionId={}, response={}",
+                    interview.getSessionId(), preview(llmResponse), e);
             interview.fail();
             interviewRepository.save(interview);
         }
     }
 
-    /**
-     * answerSummary(JSON 배열)를 파싱해 줄바꿈으로 이어붙인 문자열을 반환한다.
-     * answerSummary가 없으면 answerContent(STT 원문)로 폴백한다.
-     */
-    private String parseAnswerSummary(InterviewQna qna) {
-        String summary = qna.getAnswerSummary();
-        if (summary == null || summary.isBlank()) {
-            return qna.getAnswerContent() != null ? qna.getAnswerContent() : "답변 없음";
+    private boolean shouldEvaluateTurn(InterviewQna qna) {
+        return hasQuestion(qna)
+                && qna.getAnswerSummary() != null
+                && (isBlank(qna.getModelAnswer()) || isBlank(qna.getIndividualFeedback()));
+    }
+
+    private boolean hasQuestion(InterviewQna qna) {
+        return qna.getQuestionContent() != null && !qna.getQuestionContent().isBlank();
+    }
+
+    private String answerSummaryText(InterviewQna qna) {
+        String raw = qna.getAnswerSummary();
+        if (raw == null || raw.isBlank()) {
+            return "답변 요약 없음";
         }
+
         try {
-            JsonNode node = objectMapper.readTree(summary);
+            JsonNode node = objectMapper.readTree(raw);
             if (node.isArray()) {
+                if (node.isEmpty()) {
+                    return "답변 요약 없음";
+                }
                 StringBuilder sb = new StringBuilder();
                 for (JsonNode item : node) {
-                    if (sb.length() > 0) sb.append("\n");
-                    sb.append(item.asText());
+                    if (!item.asText("").isBlank()) {
+                        if (sb.length() > 0) {
+                            sb.append(' ');
+                        }
+                        sb.append(item.asText());
+                    }
                 }
-                return sb.isEmpty() ? (qna.getAnswerContent() != null ? qna.getAnswerContent() : "답변 없음") : sb.toString();
+                return sb.length() == 0 ? "답변 요약 없음" : sb.toString();
             }
-            return summary;
-        } catch (Exception e) {
-            return qna.getAnswerContent() != null ? qna.getAnswerContent() : "답변 없음";
+        } catch (Exception ignored) {
+            // Keep the raw value when older rows contain plain text.
         }
+        return raw;
     }
 
     private String extractJson(String llmResponse) {
-        if (llmResponse == null) return "";
+        if (llmResponse == null) {
+            return "";
+        }
         String response = llmResponse.trim();
         if (response.startsWith("```")) {
             response = response
@@ -189,4 +285,26 @@ public class EvaluationService {
         return response;
     }
 
+    private void waitForLastAgentSave() {
+        try {
+            Thread.sleep(5_000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private String valueOrDefault(String value, String defaultValue) {
+        return isBlank(value) ? defaultValue : value;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private String preview(String value) {
+        if (value == null || value.length() <= 200) {
+            return value;
+        }
+        return value.substring(0, 200);
+    }
 }

--- a/src/main/java/com/capstone/interview/service/InternalQnaService.java
+++ b/src/main/java/com/capstone/interview/service/InternalQnaService.java
@@ -1,15 +1,17 @@
 package com.capstone.interview.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.capstone.interview.dto.InternalQnaRequest;
 import com.capstone.interview.entity.Interview;
 import com.capstone.interview.entity.InterviewQna;
+import com.capstone.interview.event.QnaSavedEvent;
 import com.capstone.interview.exception.SessionNotFoundException;
 import com.capstone.interview.repository.InterviewQnaRepository;
 import com.capstone.interview.repository.InterviewRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,23 +23,21 @@ public class InternalQnaService {
     private final InterviewRepository interviewRepository;
     private final InterviewQnaRepository interviewQnaRepository;
     private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
-     * Agent 가 매 턴 전송하는 Q+A 를 upsert 한다.
-     * (session_id, turn_number) 유니크 제약 기반 — 같은 턴이 재시도로 두 번 도착해도
-     * DB 는 최종 상태 하나만 유지한다.
+     * Upserts Q+A sent by the Agent. The unique key is (interview, sequenceNumber).
      */
     @Transactional
     public void upsertQna(String sessionId, InternalQnaRequest request) {
         Interview interview = interviewRepository.findBySessionId(sessionId)
-                .orElseThrow(() -> new SessionNotFoundException("존재하지 않는 세션입니다: " + sessionId));
+                .orElseThrow(() -> new SessionNotFoundException("존재하지 않는 세션입니다. " + sessionId));
 
         InterviewQna existing = interviewQnaRepository
                 .findByInterviewAndSequenceNumber(interview, request.turnNumber())
                 .orElse(null);
 
         if (existing != null) {
-            // upsert: 기존 레코드 업데이트
             if (request.question() != null) {
                 existing.updateQuestion(
                         request.question(),
@@ -61,9 +61,8 @@ public class InternalQnaService {
                                 : existing.getFocusPoint()
                 );
             }
-            log.info("[QnA upsert] 기존 턴 업데이트. sessionId={}, turn={}", sessionId, request.turnNumber());
+            log.info("[QnA upsert] updated sessionId={}, turn={}", sessionId, request.turnNumber());
         } else {
-            // insert: 새 레코드 생성
             InterviewQna newQna = InterviewQna.builder()
                     .interview(interview)
                     .sequenceNumber(request.turnNumber())
@@ -76,7 +75,11 @@ public class InternalQnaService {
                     .focusPoint(request.focusPoint())
                     .build();
             interviewQnaRepository.save(newQna);
-            log.info("[QnA insert] 새 턴 저장. sessionId={}, turn={}", sessionId, request.turnNumber());
+            log.info("[QnA insert] created sessionId={}, turn={}", sessionId, request.turnNumber());
+        }
+
+        if (request.turnNumber() != null && request.answerSummary() != null) {
+            eventPublisher.publishEvent(new QnaSavedEvent(sessionId, request.turnNumber()));
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,14 @@ livekit:
   api-secret: ${LIVEKIT_API_SECRET}
   agent-name: ${LIVEKIT_AGENT_NAME:interviewer-agent}
 
+llm:
+  provider: ${LLM_PROVIDER:mock}
+  bedrock:
+    region: ${AWS_REGION:us-east-1}
+    model-id: ${LLM_MODEL:us.anthropic.claude-sonnet-4-6}
+    max-tokens: ${LLM_MAX_TOKENS:1200}
+    temperature: ${LLM_TEMPERATURE:0.2}
+
 jwt:
   secret: ${JWT_SECRET}
   expiration: 3600000  # 1시간 (밀리초). 리프레쉬 토큰 추가시 짧게 바꿔야 함.

--- a/src/test/java/com/capstone/interview/service/EvaluationFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/EvaluationFlowTest.java
@@ -48,7 +48,7 @@ class EvaluationFlowTest {
         evaluationService = new EvaluationService(
                 interviewRepository, interviewQnaRepository, llmClient, objectMapper);
         feedbackService = new FeedbackService(
-                interviewRepository, interviewQnaRepository, memberRepository);
+                interviewRepository, interviewQnaRepository, memberRepository, objectMapper);
 
         Member member = createMember(1L, "test1", "Tester");
         testInterview = createInterview(1L, "sess-test-0001", member, "BACKEND");
@@ -68,11 +68,15 @@ class EvaluationFlowTest {
                 .thenReturn(Optional.of(testInterview));
         when(interviewQnaRepository.findByInterviewOrderBySequenceNumberAsc(testInterview))
                 .thenReturn(testQnas);
+        for (InterviewQna qna : testQnas) {
+            when(interviewQnaRepository.findByInterviewAndSequenceNumber(testInterview, qna.getSequenceNumber()))
+                    .thenReturn(Optional.of(qna));
+        }
         when(interviewQnaRepository.saveAll(anyList()))
                 .thenAnswer(inv -> inv.getArgument(0));
         when(interviewRepository.save(any(Interview.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
-        when(interviewRepository.findByMemberIdOrderByCreatedAtDesc(1L))
+        when(interviewRepository.findByMemberIdAndStatusOrderByCreatedAtDesc(eq(1L), any()))
                 .thenReturn(List.of(testInterview));
         when(memberRepository.findByLoginId("test1"))
                 .thenReturn(Optional.of(member));
@@ -157,7 +161,6 @@ class EvaluationFlowTest {
         System.out.println("[Output] FeedbackListDto:");
         System.out.println("  sessionId: " + item.sessionId());
         System.out.println("  category: " + item.category());
-        System.out.println("  status: " + item.status());
         System.out.println("  overallScore: " + item.overallScore());
         System.out.println("  createdAt: " + item.createdAt());
 
@@ -194,6 +197,7 @@ class EvaluationFlowTest {
         setField(qna, "sequenceNumber", seq);
         setField(qna, "questionContent", question);
         setField(qna, "answerContent", answer);
+        setField(qna, "answerSummary", "[\"" + answer.replace("\"", "\\\"") + "\"]");
         setField(qna, "isFollowUp", followUp);
         setField(qna, "createdAt", LocalDateTime.now());
         setField(qna, "updatedAt", LocalDateTime.now());

--- a/src/test/java/com/capstone/interview/service/MockLLMFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/MockLLMFlowTest.java
@@ -1,85 +1,58 @@
 package com.capstone.interview.service;
 
-import com.capstone.interview.config.MockLLMClient;
 import com.capstone.interview.config.LLMClient;
+import com.capstone.interview.config.MockLLMClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * MockLLMClient의 응답이 EvaluationService 파싱 로직과 호환되는지 검증.
- * DB/Spring 컨텍스트 없이 순수 단위 테스트.
- */
 class MockLLMFlowTest {
 
     private final LLMClient llmClient = new MockLLMClient();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    void mockLLM_응답이_정상_JSON으로_파싱되는지() throws Exception {
-        // MockLLM 호출
-        String response = llmClient.invoke("테스트 프롬프트");
-
-        // JSON 파싱
+    void mockLLM_returns_turn_evaluation_json() throws Exception {
+        String response = llmClient.invoke("turn evaluator", "질문과 답변 요약으로 individual_feedback과 model_answer를 생성하세요.");
         JsonNode root = objectMapper.readTree(response.trim());
 
-        // individual_feedbacks 존재 확인
-        assertTrue(root.has("individual_feedbacks"));
-        assertTrue(root.path("individual_feedbacks").isArray());
-        assertEquals(1, root.path("individual_feedbacks").size());
-
-        // total_feedback 존재 확인
-        assertTrue(root.has("total_feedback"));
-        assertFalse(root.path("total_feedback").asText().isBlank());
-
-        // competency_chart 존재 확인
-        assertTrue(root.has("competency_chart"));
-        assertEquals(80, root.path("competency_chart").path("기술역량").asInt());
-
-        // overall_score 존재 확인
-        assertEquals("중", root.path("overall_score").asText());
-
-        System.out.println("=== MockLLM 응답 ===");
-        System.out.println(response);
-        System.out.println("=== 파싱 결과 ===");
-        System.out.println("total_feedback: " + root.path("total_feedback").asText());
-        System.out.println("overall_score: " + root.path("overall_score").asText());
-        System.out.println("competency_chart: " + root.path("competency_chart"));
+        assertTrue(root.has("individual_feedback"));
+        assertTrue(root.has("model_answer"));
+        assertFalse(root.path("individual_feedback").asText().isBlank());
+        assertFalse(root.path("model_answer").asText().isBlank());
     }
 
     @Test
-    void combined_포맷_저장_후_FeedbackService_파싱_검증() {
-        // EvaluationService가 저장하는 포맷 시뮬레이션
+    void mockLLM_returns_total_evaluation_json() throws Exception {
+        String response = llmClient.invoke("total evaluator", "total_feedback, overall_score, competency_chart를 생성하세요.");
+        JsonNode root = objectMapper.readTree(response.trim());
+
+        assertTrue(root.has("total_feedback"));
+        assertTrue(root.has("overall_score"));
+        assertTrue(root.has("competency_chart"));
+        assertEquals("중", root.path("overall_score").asText());
+        assertTrue(root.path("competency_chart").path("기술역량").asInt() > 0);
+    }
+
+    @Test
+    void combined_format_can_be_split_for_feedback_response() {
         String totalFeedback = "전반적으로 준비가 잘 된 면접이었습니다.";
         String overallScore = "중";
-        String competencyChart = "{\"기술역량\":80}";
+        String competencyChart = "{\"기술역량\":7}";
 
         String combined = totalFeedback + "\n\n[SCORE]\n" + overallScore + "\n\n[CHART]\n" + competencyChart;
 
-        System.out.println("=== 저장되는 combined 문자열 ===");
-        System.out.println(combined);
-        System.out.println("================================");
-
-        // FeedbackService.getFeedback() 파싱 로직 재현
         String onlyFeedback = combined.split("\n\n\\[SCORE\\]")[0];
-        assertEquals("전반적으로 준비가 잘 된 면접이었습니다.", onlyFeedback);
+        assertEquals(totalFeedback, onlyFeedback);
 
-        // extractChartData 로직 재현
         String chart = combined.substring(combined.indexOf("[CHART]") + "[CHART]".length()).trim();
-        assertEquals("{\"기술역량\":80}", chart);
+        assertEquals(competencyChart, chart);
 
-        // extractOverallScore 로직 재현
-        int tagEnd = combined.indexOf("[SCORE]") + "[SCORE]".length();
-        int start = combined.indexOf("\n", tagEnd);
-        start++;
-        int end = combined.indexOf("\n", start);
+        int start = combined.indexOf("[SCORE]") + "[SCORE]\n".length();
+        int end = combined.indexOf("\n\n[CHART]", start);
         String score = combined.substring(start, end).trim();
-        assertEquals("중", score);
-
-        System.out.println("onlyFeedback: " + onlyFeedback);
-        System.out.println("chart: " + chart);
-        System.out.println("score: " + score);
+        assertEquals(overallScore, score);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  sql:
+    init:
+      mode: never
+
+livekit:
+  url: ws://localhost
+  api-key: test
+  api-secret: test
+  agent-name: interviewer-agent
+
+jwt:
+  secret: test-secret-key-for-context-loads-test-secret-key
+  expiration: 3600000
+
+llm:
+  provider: mock
+
+cors:
+  allowed-origins: http://localhost:5173


### PR DESCRIPTION
﻿## 관련 Issue
- 없음

## 변경 사항
- 피드백 생성을 턴별 평가와 종합 평가로 분리했습니다.
- QnA 저장 트랜잭션 커밋 이후 `QnaSavedEvent`를 통해 개별 피드백/모범답안을 비동기로 생성하도록 연결했습니다.
- 종합 평가는 원문 답변 대신 `질문 + 답변 요약 + 개별 피드백` 압축 입력만 사용하도록 바꿨습니다.
- `question_type` 등 현재 화면에서 쓰지 않는 LLM 출력 필드를 제거하고, 실제 사용 필드만 생성하도록 프롬프트/파싱을 정리했습니다.
- `LLMClient`에 system/user prompt 분리 호출을 추가하고, Bedrock Claude 호출 구현체와 mock 구현체를 provider 설정으로 전환했습니다.
- 테스트 환경에서 H2와 dummy 설정으로 Spring context가 뜨도록 보강했습니다.

## 접근 방식
- 턴별 평가 출력은 `individual_feedback`, `model_answer`만 받도록 최소화했습니다.
- 종합 평가 출력은 기존 프론트 계약을 유지하기 위해 `total_feedback`, `overall_score`, `competency_chart`만 받습니다.
- 기존 `FeedbackService` 응답 구조는 유지하여 프론트 변경 없이 결과 화면이 계속 동작하도록 했습니다.
- 마지막 QnA 저장 지연 가능성은 기존처럼 최종 평가 시작 전 짧게 대기하고, 누락된 턴별 평가가 있으면 최종 평가 직전에 보정합니다.

## AI 사용 여부
- Codex를 사용해 평가 흐름 리팩터링, 프롬프트 분리, Bedrock 클라이언트 구현, 테스트 보강을 진행했습니다.
- 변경된 LLM 출력 스키마와 저장/조회 경로는 직접 테스트로 검증했습니다.

## 테스트
- `./gradlew test`
- `./gradlew assemble`
