### PR TITLE
feat: 이력서 삭제 기능 추가 (FK 참조 체크 포함)

### DIFF
--- a/src/main/java/com/capstone/interview/controller/ResumeController.java
+++ b/src/main/java/com/capstone/interview/controller/ResumeController.java
@@ -86,4 +86,20 @@ public class ResumeController {
     public ResponseEntity<ResumeResponse> getResume(@PathVariable Long id) {
         return ResponseEntity.ok(resumeService.getResume(id));
     }
+
+    /**
+     * 이력서 삭제.
+     * DELETE /v1/resumes/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteResume(
+            Authentication authentication,
+            @PathVariable Long id) {
+
+        String loginId = authentication.getName();
+        log.info("[이력서 삭제] loginId={}, resumeId={}", loginId, id);
+
+        resumeService.deleteResume(loginId, id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/capstone/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewRepository.java
@@ -13,4 +13,6 @@ public interface InterviewRepository extends JpaRepository<Interview, Long> {
     List<Interview> findByMemberIdOrderByCreatedAtDesc(Long memberId);
     //피드백 목록 조회 : 해당 회원의 COMPLETED 상태 면접만 최신순 조회
     List<Interview> findByMemberIdAndStatusOrderByCreatedAtDesc(Long memberId, InterviewStatus status);
+    // 이력서 삭제 시 참조 여부 확인
+    boolean existsByResumeId(Long resumeId);
 }

--- a/src/main/java/com/capstone/interview/service/ResumeService.java
+++ b/src/main/java/com/capstone/interview/service/ResumeService.java
@@ -4,6 +4,7 @@ import com.capstone.interview.dto.ResumeResponse;
 import com.capstone.interview.dto.ResumeUploadRequest;
 import com.capstone.interview.entity.Member;
 import com.capstone.interview.entity.Resume;
+import com.capstone.interview.repository.InterviewRepository;
 import com.capstone.interview.repository.MemberRepository;
 import com.capstone.interview.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class ResumeService {
     private final PdfParserService pdfParserService;
     private final ResumeRepository resumeRepository;
     private final MemberRepository memberRepository;
+    private final InterviewRepository interviewRepository;
 
     /**
      * PDF 이력서를 업로드하고 파싱하여 DB에 저장한다.
@@ -104,6 +106,30 @@ public class ResumeService {
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(() -> new IllegalArgumentException("이력서를 찾을 수 없습니다: " + resumeId));
         return toResponse(resume);
+    }
+
+    /**
+     * 이력서를 삭제한다. 본인의 이력서만 삭제 가능.
+     * 면접 기록에서 참조 중인 이력서는 삭제할 수 없다.
+     */
+    @Transactional
+    public void deleteResume(String loginId, Long resumeId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new IllegalArgumentException("이력서를 찾을 수 없습니다: " + resumeId));
+
+        if (!resume.getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("본인의 이력서만 삭제할 수 있습니다.");
+        }
+
+        if (interviewRepository.existsByResumeId(resumeId)) {
+            throw new IllegalArgumentException("면접 기록에서 사용 중인 이력서는 삭제할 수 없습니다.");
+        }
+
+        resumeRepository.delete(resume);
+        log.info("[이력서 삭제] id={}, memberId={}", resumeId, member.getId());
     }
 
     private ResumeResponse toResponse(Resume resume) {


### PR DESCRIPTION
## 관련 Issue
- closes #이슈번호

- 이력서 삭제 API 추가 (DELETE /v1/resumes/{id})
- 본인 이력서만 삭제 가능하도록 소유자 검증
- 면접 기록에서 참조 중인 이력서는 삭제 불가 (FK 제약 위반 방지)

## 접근 방식
- InterviewRepository에 existsByResumeId 메서드 추가하여 참조 여부 확인
- 참조 중이면 400 에러로 "면접 기록에서 사용 중인 이력서는 삭제할 수 없습니다" 반환
- DB 레벨 FK 에러(500) 대신 서비스 레벨에서 사전 차단

## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
