### PR TITLE
feat: 이력서 삭제 + 면접 기록 삭제 기능 추가

### DIFF
--- a/src/main/java/com/capstone/interview/controller/InterviewController.java
+++ b/src/main/java/com/capstone/interview/controller/InterviewController.java
@@ -51,4 +51,13 @@ public class InterviewController {
         log.info("[세션 종료 성공] sessionId={}, status={}", sessionId, response.data().status());
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{sessionId}")
+    public ResponseEntity<Void> deleteSession(@PathVariable String sessionId) {
+        log.info("[면접 기록 삭제 요청] sessionId={}", sessionId);
+
+        interviewService.deleteSession(sessionId);
+        log.info("[면접 기록 삭제 성공] sessionId={}", sessionId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/capstone/interview/controller/ResumeController.java
+++ b/src/main/java/com/capstone/interview/controller/ResumeController.java
@@ -86,4 +86,20 @@ public class ResumeController {
     public ResponseEntity<ResumeResponse> getResume(@PathVariable Long id) {
         return ResponseEntity.ok(resumeService.getResume(id));
     }
+
+    /**
+     * 이력서 삭제.
+     * DELETE /v1/resumes/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteResume(
+            Authentication authentication,
+            @PathVariable Long id) {
+
+        String loginId = authentication.getName();
+        log.info("[이력서 삭제] loginId={}, resumeId={}", loginId, id);
+
+        resumeService.deleteResume(loginId, id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/capstone/interview/entity/Interview.java
+++ b/src/main/java/com/capstone/interview/entity/Interview.java
@@ -85,6 +85,10 @@ public class Interview {
         this.status = InterviewStatus.FAILED;
     }
 
+    public void clearResume() {
+        this.resume = null;
+    }
+
     //EvaluationService에서 total_feedback 저장을 위해 호출
     public void saveTotalFeedback(String totalFeedback) {
         this.totalFeedback = totalFeedback;

--- a/src/main/java/com/capstone/interview/repository/InterviewQnaRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewQnaRepository.java
@@ -11,4 +11,8 @@ public interface InterviewQnaRepository extends JpaRepository<InterviewQna, Long
     List<InterviewQna> findByInterviewOrderBySequenceNumberAsc(Interview interview);
     Optional<InterviewQna> findByInterviewAndSequenceNumber(Interview interview, Integer sequenceNumber);
     int countByInterview(Interview interview);
+    // 면접 기록 삭제 시 관련 QnA 일괄 삭제 (셀프 참조 FK 고려하여 네이티브 쿼리 사용)
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.data.jpa.repository.Query("DELETE FROM InterviewQna q WHERE q.interview = :interview")
+    void deleteAllByInterview(@org.springframework.data.repository.query.Param("interview") Interview interview);
 }

--- a/src/main/java/com/capstone/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewRepository.java
@@ -13,4 +13,6 @@ public interface InterviewRepository extends JpaRepository<Interview, Long> {
     List<Interview> findByMemberIdOrderByCreatedAtDesc(Long memberId);
     //피드백 목록 조회 : 해당 회원의 COMPLETED 상태 면접만 최신순 조회
     List<Interview> findByMemberIdAndStatusOrderByCreatedAtDesc(Long memberId, InterviewStatus status);
+    // 이력서 삭제 시 참조 해제용
+    List<Interview> findByResumeId(Long resumeId);
 }

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -226,4 +226,21 @@ public class InterviewService {
                     "IN_PROGRESS 상태에서만 가능합니다. 현재: " + interview.getStatus());
         }
     }
+
+    /**
+     * 면접 기록을 삭제한다. 본인의 면접 기록만 삭제 가능.
+     * 관련 QnA 데이터도 함께 삭제된다.
+     */
+    @Transactional
+    public void deleteSession(String sessionId) {
+        Interview interview = findInterviewOrThrow(sessionId);
+        verifyOwner(interview);
+
+        // QnA 데이터 먼저 삭제
+        interviewQnaRepository.deleteAllByInterview(interview);
+
+        // 면접 기록 삭제
+        interviewRepository.delete(interview);
+        log.info("[면접 기록 삭제] sessionId={}", sessionId);
+    }
 }

--- a/src/main/java/com/capstone/interview/service/ResumeService.java
+++ b/src/main/java/com/capstone/interview/service/ResumeService.java
@@ -4,6 +4,7 @@ import com.capstone.interview.dto.ResumeResponse;
 import com.capstone.interview.dto.ResumeUploadRequest;
 import com.capstone.interview.entity.Member;
 import com.capstone.interview.entity.Resume;
+import com.capstone.interview.repository.InterviewRepository;
 import com.capstone.interview.repository.MemberRepository;
 import com.capstone.interview.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class ResumeService {
     private final PdfParserService pdfParserService;
     private final ResumeRepository resumeRepository;
     private final MemberRepository memberRepository;
+    private final InterviewRepository interviewRepository;
 
     /**
      * PDF 이력서를 업로드하고 파싱하여 DB에 저장한다.
@@ -104,6 +106,30 @@ public class ResumeService {
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(() -> new IllegalArgumentException("이력서를 찾을 수 없습니다: " + resumeId));
         return toResponse(resume);
+    }
+
+    /**
+     * 이력서를 삭제한다. 본인의 이력서만 삭제 가능.
+     * 면접 기록에서 참조 중인 경우 참조를 해제(NULL)한 뒤 삭제한다.
+     */
+    @Transactional
+    public void deleteResume(String loginId, Long resumeId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new IllegalArgumentException("이력서를 찾을 수 없습니다: " + resumeId));
+
+        if (!resume.getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("본인의 이력서만 삭제할 수 있습니다.");
+        }
+
+        // 면접 기록에서 이력서 참조 해제
+        interviewRepository.findByResumeId(resumeId)
+                .forEach(interview -> interview.clearResume());
+
+        resumeRepository.delete(resume);
+        log.info("[이력서 삭제] id={}, memberId={}", resumeId, member.getId());
     }
 
     private ResumeResponse toResponse(Resume resume) {


### PR DESCRIPTION
## 관련 Issue
- closes #이슈번호

## 변경 사항
- 이력서 삭제 API 추가 (DELETE /v1/resumes/{id})
- 면접 기록 삭제 API 추가 (DELETE /v1/interviews/sessions/{sessionId})
- 이력서 삭제 시 면접 기록의 resume 참조를 NULL로 해제하여 FK 제약 없이 삭제 가능
- 면접 기록 삭제 시 관련 QnA 데이터도 함께 삭제

## 접근 방식
- 이력서 삭제: Interview.clearResume()으로 참조 해제 후 삭제 (면접 기록은 유지)
- 면접 기록 삭제: QnA 먼저 삭제 → Interview 삭제 (FK 순서 준수)
- 본인 소유 검증 포함


## 머지 전 체크리스트
- [ ] PR description이 양식대로 작성되었는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [ ] 테스트가 통과하는가
- [ ] 불필요한 console.log나 디버깅 코드가 제거되었는가
