### PR TITLE
[Chore] .env.example Bedrock 환경 변수 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,17 @@ LIVEKIT_API_SECRET=
 # 생성 예시: openssl rand -base64 32
 INTERNAL_SERVICE_TOKEN=change-me-to-a-shared-secret
 
+# --- LLM / Bedrock ---
+# mock: MockLLMClient (default, works without AWS credentials)
+# bedrock: BedrockLLMClient (real Bedrock invocation)
+LLM_PROVIDER=mock
+
+# Used when LLM_PROVIDER=bedrock
+AWS_REGION=us-east-1
+LLM_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
+LLM_MAX_TOKENS=1200
+LLM_TEMPERATURE=0.2
+
 # --- CORS ---
 # 허용할 프론트엔드 출처 (쉼표로 구분).
 # 로컬 개발: http://localhost:5173,http://localhost:5174


### PR DESCRIPTION
﻿## 관련 Issue
- 없음

## 변경 사항
- `.env.example`에 Bedrock LLM 관련 환경 변수를 추가했습니다.
- 추가 항목: `LLM_PROVIDER`, `AWS_REGION`, `LLM_MODEL`, `LLM_MAX_TOKENS`, `LLM_TEMPERATURE`

## 접근 방식
- 기존 앱 설정(`application.yml`)에서 참조하는 키와 동일한 이름으로 맞췄습니다.
- 기본 동작은 `LLM_PROVIDER=mock`로 유지해서 기존 로컬 개발 흐름을 깨지 않도록 했습니다.

## AI 사용 여부
- Codex를 사용해 누락된 환경 변수 항목을 정리하고 반영했습니다.
- 실제 참조 키는 코드(`application.yml`, Bedrock 클라이언트 설정)와 대조해 확인했습니다.

## 테스트
- 문서 파일 변경만 포함되어 별도 런타임 테스트는 수행하지 않았습니다.
