### PR TITLE
feat: 그룹 면접(SOLO/GROUP) 및 참가자 로비/참여 기능 추가

### DIFF
--- a/scripts/add-group-interview-support.sql
+++ b/scripts/add-group-interview-support.sql
@@ -1,0 +1,25 @@
+-- Group interview support (manual migration for prod ddl-auto: validate)
+
+ALTER TABLE interviews ADD COLUMN IF NOT EXISTS max_participants INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE interviews ADD COLUMN IF NOT EXISTS mode VARCHAR(20) NOT NULL DEFAULT 'SOLO';
+ALTER TABLE interviews ADD COLUMN IF NOT EXISTS current_speaker_member_id BIGINT;
+
+ALTER TABLE interview_qnas ADD COLUMN IF NOT EXISTS respondent_member_id BIGINT;
+
+CREATE TABLE IF NOT EXISTS interview_participants (
+    id BIGSERIAL PRIMARY KEY,
+    interview_id BIGINT NOT NULL REFERENCES interviews(id),
+    member_id BIGINT NOT NULL REFERENCES members(id),
+    role VARCHAR(20) NOT NULL,
+    ready BOOLEAN NOT NULL DEFAULT FALSE,
+    joined_at TIMESTAMP NOT NULL,
+    resume_id BIGINT REFERENCES resumes(id),
+    total_feedback TEXT,
+    overall_score VARCHAR(20),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT uk_interview_participant UNIQUE (interview_id, member_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_interview_participants_interview ON interview_participants(interview_id);
+CREATE INDEX IF NOT EXISTS idx_interview_participants_member ON interview_participants(member_id);

--- a/src/main/java/com/capstone/interview/controller/FeedbackController.java
+++ b/src/main/java/com/capstone/interview/controller/FeedbackController.java
@@ -29,15 +29,13 @@ public class FeedbackController {
      * * @return 개별평가, 개별모범답안, 전체 피드백이 모두 담긴 FeedbackResponse
      */
     @GetMapping("/feedback/{sessionId}")
-    public ResponseEntity<FeedbackResponse> getFeedback(@PathVariable String sessionId) {
+    public ResponseEntity<FeedbackResponse> getFeedback(
+            @PathVariable String sessionId,
+            Authentication authentication) {
         log.info("[피드백 조회 시작] sessionId: {}", sessionId);
-
-        // 1. 서비스에서 모든 피드백 정보(전체 총평 + 개별 문항 세트)를 가져옴
-        FeedbackResponse response = feedbackService.getFeedback(sessionId);
-
+        String loginId = authentication.getName();
+        FeedbackResponse response = feedbackService.getFeedback(sessionId, loginId);
         log.info("[피드백 조회 완료] sessionId: {}", sessionId);
-
-        // 2. ResponseEntity에 FeedbackResponse 객체를 담아 전송
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/capstone/interview/controller/InterviewController.java
+++ b/src/main/java/com/capstone/interview/controller/InterviewController.java
@@ -1,5 +1,8 @@
 package com.capstone.interview.controller;
 
+import com.capstone.interview.dto.JoinSessionRequest;
+import com.capstone.interview.dto.JoinSessionResponse;
+import com.capstone.interview.dto.LobbyResponse;
 import com.capstone.interview.dto.NextTurnRequest;
 import com.capstone.interview.dto.NextTurnResponse;
 import com.capstone.interview.dto.SessionCreateRequest;
@@ -50,6 +53,26 @@ public class InterviewController {
         SessionEndResponse response = interviewService.endSession(sessionId, request.reason());
         log.info("[세션 종료 성공] sessionId={}, status={}", sessionId, response.data().status());
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{sessionId}/join")
+    public ResponseEntity<JoinSessionResponse> joinSession(
+            @PathVariable String sessionId,
+            @RequestBody(required = false) JoinSessionRequest request) {
+        log.info("[세션 입장] sessionId={}", sessionId);
+        JoinSessionResponse response = interviewService.joinSession(sessionId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{sessionId}/lobby")
+    public ResponseEntity<LobbyResponse> getLobby(@PathVariable String sessionId) {
+        return ResponseEntity.ok(interviewService.getLobby(sessionId));
+    }
+
+    @PatchMapping("/{sessionId}/participants/me/ready")
+    public ResponseEntity<LobbyResponse> setReady(@PathVariable String sessionId) {
+        log.info("[준비 완료] sessionId={}", sessionId);
+        return ResponseEntity.ok(interviewService.setReady(sessionId));
     }
 
     @DeleteMapping("/{sessionId}")

--- a/src/main/java/com/capstone/interview/dto/InternalQnaRequest.java
+++ b/src/main/java/com/capstone/interview/dto/InternalQnaRequest.java
@@ -10,5 +10,6 @@ public record InternalQnaRequest(
     String answer,
     List<String> answerSummary,
     String followUpDecision,
-    String focusPoint
+    String focusPoint,
+    Long respondentMemberId
 ) {}

--- a/src/main/java/com/capstone/interview/dto/JoinSessionRequest.java
+++ b/src/main/java/com/capstone/interview/dto/JoinSessionRequest.java
@@ -1,0 +1,5 @@
+package com.capstone.interview.dto;
+
+public record JoinSessionRequest(
+    Long resumeId
+) {}

--- a/src/main/java/com/capstone/interview/dto/JoinSessionResponse.java
+++ b/src/main/java/com/capstone/interview/dto/JoinSessionResponse.java
@@ -1,0 +1,16 @@
+package com.capstone.interview.dto;
+
+public record JoinSessionResponse(
+    boolean success,
+    JoinSessionResponse.Data data
+) {
+    public record Data(
+        String sessionId,
+        SessionCreateResponse.LiveKitInfo livekit,
+        String mode,
+        String status,
+        String role,
+        String myIdentity,
+        int maxParticipants
+    ) {}
+}

--- a/src/main/java/com/capstone/interview/dto/LobbyResponse.java
+++ b/src/main/java/com/capstone/interview/dto/LobbyResponse.java
@@ -1,0 +1,23 @@
+package com.capstone.interview.dto;
+
+import java.util.List;
+
+public record LobbyResponse(
+    boolean success,
+    LobbyResponse.Data data
+) {
+    public record Data(
+        String sessionId,
+        String status,
+        String mode,
+        int maxParticipants,
+        int currentParticipants,
+        int readyCount,
+        boolean allReady,
+        String myRole,
+        String myIdentity,
+        boolean myReady,
+        List<ParticipantDto> participants,
+        SessionCreateResponse.LiveKitInfo livekit
+    ) {}
+}

--- a/src/main/java/com/capstone/interview/dto/ParticipantDto.java
+++ b/src/main/java/com/capstone/interview/dto/ParticipantDto.java
@@ -1,0 +1,10 @@
+package com.capstone.interview.dto;
+
+public record ParticipantDto(
+    Long memberId,
+    String name,
+    String loginId,
+    String role,
+    boolean ready,
+    String identity
+) {}

--- a/src/main/java/com/capstone/interview/dto/SessionCreateRequest.java
+++ b/src/main/java/com/capstone/interview/dto/SessionCreateRequest.java
@@ -4,5 +4,6 @@ public record SessionCreateRequest(
     Long resumeIds,         // optional
     Long coverLetter,       // optional
     String jobField,        // 필수
-    Integer durationMinutes // 필수
+    Integer durationMinutes, // 필수
+    Integer maxParticipants  // optional, default 1
 ) {}

--- a/src/main/java/com/capstone/interview/dto/SessionCreateResponse.java
+++ b/src/main/java/com/capstone/interview/dto/SessionCreateResponse.java
@@ -8,7 +8,10 @@ public record SessionCreateResponse(
         String sessionId,
         LiveKitInfo livekit,
         int answerTimeLimitSeconds,
-        int totalDurationSeconds
+        int totalDurationSeconds,
+        String mode,
+        int maxParticipants,
+        String status
     ) {}
 
     public record LiveKitInfo(

--- a/src/main/java/com/capstone/interview/entity/Interview.java
+++ b/src/main/java/com/capstone/interview/entity/Interview.java
@@ -41,6 +41,16 @@ public class Interview {
     @Column(name = "duration_minutes")
     private Integer durationMinutes;
 
+    @Column(name = "max_participants", nullable = false)
+    private Integer maxParticipants = 1;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private InterviewMode mode = InterviewMode.SOLO;
+
+    @Column(name = "current_speaker_member_id")
+    private Long currentSpeakerMemberId;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private InterviewStatus status = InterviewStatus.READY;
@@ -56,7 +66,8 @@ public class Interview {
 
     @Builder
     public Interview(Member member, Resume resume, CoverLetter coverLetter,
-                     String category, String sessionId, String roomName, Integer durationMinutes) {
+                     String category, String sessionId, String roomName, Integer durationMinutes,
+                     Integer maxParticipants, InterviewMode mode) {
         this.member = member;
         this.resume = resume;
         this.coverLetter = coverLetter;
@@ -64,14 +75,35 @@ public class Interview {
         this.sessionId = sessionId;
         this.roomName = roomName;
         this.durationMinutes = durationMinutes;
+        this.maxParticipants = maxParticipants != null ? maxParticipants : 1;
+        this.mode = mode != null ? mode : InterviewMode.SOLO;
         this.status = InterviewStatus.READY;
     }
 
-    public void start() {
+    public void enterWaitingLobby() {
         if (this.status != InterviewStatus.READY) {
+            throw new IllegalStateException("READY 상태에서만 대기실로 전환할 수 있습니다. 현재: " + this.status);
+        }
+        this.status = InterviewStatus.WAITING;
+    }
+
+    public void start() {
+        if (this.mode == InterviewMode.GROUP) {
+            if (this.status != InterviewStatus.WAITING) {
+                throw new IllegalStateException("WAITING 상태에서만 시작할 수 있습니다. 현재: " + this.status);
+            }
+        } else if (this.status != InterviewStatus.READY) {
             throw new IllegalStateException("READY 상태에서만 시작할 수 있습니다. 현재: " + this.status);
         }
         this.status = InterviewStatus.IN_PROGRESS;
+    }
+
+    public boolean isGroupMode() {
+        return this.mode == InterviewMode.GROUP;
+    }
+
+    public void setCurrentSpeakerMemberId(Long memberId) {
+        this.currentSpeakerMemberId = memberId;
     }
 
     public void complete() {

--- a/src/main/java/com/capstone/interview/entity/InterviewMode.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewMode.java
@@ -1,0 +1,6 @@
+package com.capstone.interview.entity;
+
+public enum InterviewMode {
+    SOLO,
+    GROUP
+}

--- a/src/main/java/com/capstone/interview/entity/InterviewParticipant.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewParticipant.java
@@ -1,0 +1,96 @@
+package com.capstone.interview.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "interview_participants",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"interview_id", "member_id"}))
+@Getter
+@NoArgsConstructor
+public class InterviewParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_id", nullable = false)
+    private Interview interview;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ParticipantRole role;
+
+    @Column(nullable = false)
+    private boolean ready = false;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    @Column(name = "total_feedback", columnDefinition = "TEXT")
+    private String totalFeedback;
+
+    @Column(name = "overall_score", length = 20)
+    private String overallScore;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public InterviewParticipant(Interview interview, Member member, ParticipantRole role,
+                                Resume resume, boolean ready) {
+        this.interview = interview;
+        this.member = member;
+        this.role = role;
+        this.resume = resume;
+        this.ready = ready;
+        this.joinedAt = LocalDateTime.now();
+    }
+
+    public void markReady() {
+        this.ready = true;
+    }
+
+    public void saveTotalFeedback(String totalFeedback, String overallScore) {
+        this.totalFeedback = totalFeedback;
+        this.overallScore = overallScore;
+    }
+
+    public boolean hasFeedback() {
+        return totalFeedback != null;
+    }
+
+    public String liveKitIdentity() {
+        return "user-" + member.getId();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+        if (joinedAt == null) {
+            joinedAt = LocalDateTime.now();
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/capstone/interview/entity/InterviewQna.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewQna.java
@@ -22,6 +22,9 @@ public class InterviewQna {
     @JoinColumn(name = "interview_id", nullable = false)
     private Interview interview;
 
+    @Column(name = "respondent_member_id")
+    private Long respondentMemberId;
+
     @Column(name = "sequence_number", nullable = false)
     private Integer sequenceNumber;
 
@@ -80,8 +83,10 @@ public class InterviewQna {
     public InterviewQna(Interview interview, Integer sequenceNumber, String questionContent,
                         String answerContent, boolean isFollowUp, InterviewQna parent,
                         String intent, String answerSummary, String followUpDecision,
-                        String focusPoint, LocalDateTime startedAt, LocalDateTime expiresAt) {
+                        String focusPoint, LocalDateTime startedAt, LocalDateTime expiresAt,
+                        Long respondentMemberId) {
         this.interview = interview;
+        this.respondentMemberId = respondentMemberId;
         this.sequenceNumber = sequenceNumber;
         this.questionContent = questionContent;
         this.answerContent = answerContent;
@@ -93,6 +98,10 @@ public class InterviewQna {
         this.focusPoint = focusPoint;
         this.startedAt = startedAt;
         this.expiresAt = expiresAt;
+    }
+
+    public void setRespondentMemberId(Long respondentMemberId) {
+        this.respondentMemberId = respondentMemberId;
     }
 
     public void updateAnswer(String answerContent) {

--- a/src/main/java/com/capstone/interview/entity/InterviewStatus.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewStatus.java
@@ -2,6 +2,7 @@ package com.capstone.interview.entity;
 
 public enum InterviewStatus {
     READY,
+    WAITING,
     IN_PROGRESS,
     COMPLETED,
     FAILED

--- a/src/main/java/com/capstone/interview/entity/ParticipantRole.java
+++ b/src/main/java/com/capstone/interview/entity/ParticipantRole.java
@@ -1,0 +1,6 @@
+package com.capstone.interview.entity;
+
+public enum ParticipantRole {
+    HOST,
+    GUEST
+}

--- a/src/main/java/com/capstone/interview/repository/InterviewParticipantRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewParticipantRepository.java
@@ -1,0 +1,22 @@
+package com.capstone.interview.repository;
+
+import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.InterviewParticipant;
+import com.capstone.interview.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InterviewParticipantRepository extends JpaRepository<InterviewParticipant, Long> {
+
+    List<InterviewParticipant> findByInterviewOrderByJoinedAtAsc(Interview interview);
+
+    Optional<InterviewParticipant> findByInterviewAndMember(Interview interview, Member member);
+
+    long countByInterview(Interview interview);
+
+    long countByInterviewAndReadyTrue(Interview interview);
+
+    List<InterviewParticipant> findByMemberIdOrderByJoinedAtDesc(Long memberId);
+}

--- a/src/main/java/com/capstone/interview/repository/InterviewQnaRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewQnaRepository.java
@@ -9,6 +9,10 @@ import java.util.Optional;
 public interface InterviewQnaRepository extends JpaRepository<InterviewQna, Long> {
     // 면접의 모든 질문-답변을 순서대로 조회
     List<InterviewQna> findByInterviewOrderBySequenceNumberAsc(Interview interview);
+
+    List<InterviewQna> findByInterviewAndRespondentMemberIdOrderBySequenceNumberAsc(
+            Interview interview, Long respondentMemberId);
+
     Optional<InterviewQna> findByInterviewAndSequenceNumber(Interview interview, Integer sequenceNumber);
     int countByInterview(Interview interview);
     // 면접 기록 삭제 시 관련 QnA 일괄 삭제 (셀프 참조 FK 고려하여 네이티브 쿼리 사용)

--- a/src/main/java/com/capstone/interview/service/AgentDispatchService.java
+++ b/src/main/java/com/capstone/interview/service/AgentDispatchService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -48,16 +49,36 @@ public class AgentDispatchService {
     public void dispatch(String roomName, String sessionId, String jobRole,
                          String resumeText, String coverLetterText,
                          int totalDurationSeconds, int answerTimeLimitSeconds) {
-        try {
-            // metadata 구성
-            Map<String, Object> metadata = new LinkedHashMap<>();
-            metadata.put("sessionId", sessionId);
-            metadata.put("jobRole", jobRole);
-            metadata.put("resumeText", resumeText != null ? resumeText : "");
-            metadata.put("coverLetterText", coverLetterText != null ? coverLetterText : "");
-            metadata.put("totalDurationSeconds", totalDurationSeconds);
-            metadata.put("answerTimeLimitSeconds", answerTimeLimitSeconds);
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("mode", "SOLO");
+        metadata.put("sessionId", sessionId);
+        metadata.put("jobRole", jobRole);
+        metadata.put("resumeText", resumeText != null ? resumeText : "");
+        metadata.put("coverLetterText", coverLetterText != null ? coverLetterText : "");
+        metadata.put("totalDurationSeconds", totalDurationSeconds);
+        metadata.put("answerTimeLimitSeconds", answerTimeLimitSeconds);
+        createDispatch(roomName, sessionId, metadata);
+    }
 
+    public void dispatchGroup(String roomName, String sessionId, String jobRole,
+                              String resumeText, String coverLetterText,
+                              int totalDurationSeconds, int answerTimeLimitSeconds,
+                              int maxParticipants, List<Map<String, Object>> participants) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("mode", "GROUP");
+        metadata.put("sessionId", sessionId);
+        metadata.put("jobRole", jobRole);
+        metadata.put("resumeText", resumeText != null ? resumeText : "");
+        metadata.put("coverLetterText", coverLetterText != null ? coverLetterText : "");
+        metadata.put("totalDurationSeconds", totalDurationSeconds);
+        metadata.put("answerTimeLimitSeconds", answerTimeLimitSeconds);
+        metadata.put("maxParticipants", maxParticipants);
+        metadata.put("participants", participants);
+        createDispatch(roomName, sessionId, metadata);
+    }
+
+    private void createDispatch(String roomName, String sessionId, Map<String, Object> metadata) {
+        try {
             String metadataJson = objectMapper.writeValueAsString(metadata);
 
             // Twirp request body

--- a/src/main/java/com/capstone/interview/service/EvaluationService.java
+++ b/src/main/java/com/capstone/interview/service/EvaluationService.java
@@ -2,8 +2,11 @@ package com.capstone.interview.service;
 
 import com.capstone.interview.config.LLMClient;
 import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.InterviewMode;
+import com.capstone.interview.entity.InterviewParticipant;
 import com.capstone.interview.entity.InterviewQna;
 import com.capstone.interview.event.QnaSavedEvent;
+import com.capstone.interview.repository.InterviewParticipantRepository;
 import com.capstone.interview.repository.InterviewQnaRepository;
 import com.capstone.interview.repository.InterviewRepository;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -83,6 +86,7 @@ public class EvaluationService {
 
     private final InterviewRepository interviewRepository;
     private final InterviewQnaRepository interviewQnaRepository;
+    private final InterviewParticipantRepository participantRepository;
     private final LLMClient llmClient;
     private final ObjectMapper objectMapper;
 
@@ -133,6 +137,11 @@ public class EvaluationService {
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
 
+        if (interview.getMode() == InterviewMode.GROUP) {
+            evaluateAllParticipants(sessionId);
+            return;
+        }
+
         if (interview.getTotalFeedback() != null) {
             log.info("[evaluation skipped] already completed sessionId={}", sessionId);
             return;
@@ -160,6 +169,103 @@ public class EvaluationService {
                 buildTotalPrompt(interview, qnas)
         );
         parseAndSaveTotal(response, interview);
+    }
+
+    @Async
+    @Transactional
+    public void evaluateAllParticipants(String sessionId) {
+        waitForLastAgentSave();
+
+        Interview interview = interviewRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
+
+        List<InterviewParticipant> participants =
+                participantRepository.findByInterviewOrderByJoinedAtAsc(interview);
+
+        for (InterviewParticipant participant : participants) {
+            if (participant.hasFeedback()) {
+                log.info("[evaluation skipped] participant already evaluated memberId={}",
+                        participant.getMember().getId());
+                continue;
+            }
+            evaluateParticipant(interview, participant);
+        }
+    }
+
+    private void evaluateParticipant(Interview interview, InterviewParticipant participant) {
+        Long memberId = participant.getMember().getId();
+        List<InterviewQna> qnas = interviewQnaRepository
+                .findByInterviewAndRespondentMemberIdOrderBySequenceNumberAsc(interview, memberId)
+                .stream()
+                .filter(this::hasQuestion)
+                .toList();
+
+        if (qnas.isEmpty()) {
+            qnas = interviewQnaRepository.findByInterviewOrderBySequenceNumberAsc(interview)
+                    .stream()
+                    .filter(this::hasQuestion)
+                    .filter(q -> q.getRespondentMemberId() == null)
+                    .toList();
+        }
+
+        if (qnas.isEmpty()) {
+            log.warn("[evaluation skipped] no QnA for participant memberId={}", memberId);
+            return;
+        }
+
+        for (InterviewQna qna : qnas) {
+            if (shouldEvaluateTurn(qna)) {
+                evaluateTurnForQna(interview, qna);
+            }
+        }
+
+        qnas = interviewQnaRepository
+                .findByInterviewAndRespondentMemberIdOrderBySequenceNumberAsc(interview, memberId);
+        if (qnas.isEmpty()) {
+            qnas = interviewQnaRepository.findByInterviewOrderBySequenceNumberAsc(interview);
+        }
+
+        String response = llmClient.invoke(
+                TOTAL_EVALUATION_SYSTEM_PROMPT,
+                buildTotalPrompt(interview, qnas)
+        );
+        parseAndSaveParticipantTotal(response, participant);
+    }
+
+    private void evaluateTurnForQna(Interview interview, InterviewQna qna) {
+        try {
+            String response = llmClient.invoke(
+                    TURN_EVALUATION_SYSTEM_PROMPT,
+                    buildTurnPrompt(interview, qna)
+            );
+            JsonNode root = objectMapper.readTree(extractJson(response));
+            String individualFeedback = root.path("individual_feedback").asText("");
+            String modelAnswer = root.path("model_answer").asText("");
+            qna.saveFeedback(modelAnswer, individualFeedback);
+            interviewQnaRepository.save(qna);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Turn evaluation failed: " + interview.getSessionId() + "#" + qna.getSequenceNumber(), e);
+        }
+    }
+
+    private void parseAndSaveParticipantTotal(String llmResponse, InterviewParticipant participant) {
+        try {
+            JsonNode root = objectMapper.readTree(extractJson(llmResponse));
+            String totalFeedback = root.path("total_feedback").asText("피드백 정보가 없습니다.");
+            String overallScore = root.path("overall_score").asText("N/A");
+            String competencyChart = root.path("competency_chart").isMissingNode()
+                    ? "{}"
+                    : root.path("competency_chart").toString();
+
+            String combined = totalFeedback + "\n\n[SCORE]\n" + overallScore + "\n\n[CHART]\n" + competencyChart;
+            participant.saveTotalFeedback(combined, overallScore);
+            participantRepository.save(participant);
+            log.info("[participant evaluation saved] sessionId={}, memberId={}",
+                    participant.getInterview().getSessionId(), participant.getMember().getId());
+        } catch (Exception e) {
+            log.error("[participant evaluation parse failed] memberId={}", participant.getMember().getId(), e);
+        }
     }
 
     private String buildTurnPrompt(Interview interview, InterviewQna qna) {

--- a/src/main/java/com/capstone/interview/service/FeedbackService.java
+++ b/src/main/java/com/capstone/interview/service/FeedbackService.java
@@ -1,22 +1,22 @@
 package com.capstone.interview.service;
 
+import com.capstone.interview.dto.FeedbackListDto;
 import com.capstone.interview.dto.FeedbackResponse;
 import com.capstone.interview.dto.QAPair;
-import com.capstone.interview.entity.Interview;
-import com.capstone.interview.entity.InterviewQna;
-import com.capstone.interview.entity.InterviewStatus;
+import com.capstone.interview.entity.*;
+import com.capstone.interview.exception.UnauthorizedException;
+import com.capstone.interview.repository.InterviewParticipantRepository;
 import com.capstone.interview.repository.InterviewQnaRepository;
 import com.capstone.interview.repository.InterviewRepository;
+import com.capstone.interview.repository.MemberRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.capstone.interview.entity.Member;
-import com.capstone.interview.exception.UnauthorizedException;
-import com.capstone.interview.repository.MemberRepository;
 
-import com.capstone.interview.dto.FeedbackListDto;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -25,20 +25,37 @@ public class FeedbackService {
 
     private final InterviewRepository interviewRepository;
     private final InterviewQnaRepository interviewQnaRepository;
+    private final InterviewParticipantRepository participantRepository;
     private final MemberRepository memberRepository;
     private final ObjectMapper objectMapper;
 
-
-    /**
-     * 면접 결과 피드백 조회
-     */
     @Transactional(readOnly = true)
-    public FeedbackResponse getFeedback(String sessionId) {
-        // 1. 면접 정보 조회
+    public FeedbackResponse getFeedback(String sessionId, String loginId) {
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 면접 세션입니다: " + sessionId));
 
-        // 2. 피드백 생성 여부 체크 (null이면 생성 중으로 판단)
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UnauthorizedException("회원 정보를 찾을 수 없습니다."));
+
+        if (interview.isGroupMode()) {
+            InterviewParticipant participant = participantRepository
+                    .findByInterviewAndMember(interview, member)
+                    .orElseThrow(() -> new UnauthorizedException("이 면접의 참가자가 아닙니다."));
+
+            String rawFeedback = participant.getTotalFeedback();
+            if (rawFeedback == null) {
+                return FeedbackResponse.builder()
+                        .success(false)
+                        .totalFeedback("AI 피드백이 생성 중입니다. 잠시 후 다시 시도해주세요.")
+                        .build();
+            }
+
+            List<InterviewQna> qnas = interviewQnaRepository
+                    .findByInterviewAndRespondentMemberIdOrderBySequenceNumberAsc(interview, member.getId());
+
+            return buildFeedbackResponse(rawFeedback, qnas);
+        }
+
         String rawFeedback = interview.getTotalFeedback();
         if (rawFeedback == null) {
             return FeedbackResponse.builder()
@@ -47,11 +64,62 @@ public class FeedbackService {
                     .build();
         }
 
-        // 3. 질문-답변 리스트 조회
         List<InterviewQna> qnas = interviewQnaRepository
                 .findByInterviewOrderBySequenceNumberAsc(interview);
 
-        // 4. QAPair 리스트 변환 로직
+        return buildFeedbackResponse(rawFeedback, qnas);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeedbackListDto> getFeedbackList(String loginId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UnauthorizedException("회원 정보를 찾을 수 없습니다."));
+
+        List<FeedbackListDto> result = new ArrayList<>();
+
+        List<Interview> owned = interviewRepository.findByMemberIdAndStatusOrderByCreatedAtDesc(
+                member.getId(), InterviewStatus.COMPLETED);
+        for (Interview interview : owned) {
+            if (interview.isGroupMode()) {
+                participantRepository.findByInterviewAndMember(interview, member)
+                        .ifPresent(p -> result.add(toListDto(interview, p.getOverallScore())));
+            } else {
+                result.add(toListDto(interview, extractOverallScore(interview.getTotalFeedback())));
+            }
+        }
+
+        List<InterviewParticipant> guestRecords =
+                participantRepository.findByMemberIdOrderByJoinedAtDesc(member.getId());
+        for (InterviewParticipant p : guestRecords) {
+            Interview interview = p.getInterview();
+            if (interview.getStatus() != InterviewStatus.COMPLETED) {
+                continue;
+            }
+            if (interview.getMember() != null && interview.getMember().getId().equals(member.getId())) {
+                continue;
+            }
+            result.add(toListDto(interview, p.getOverallScore()));
+        }
+
+        java.util.Map<String, FeedbackListDto> bySession = new java.util.LinkedHashMap<>();
+        for (FeedbackListDto dto : result) {
+            bySession.putIfAbsent(dto.sessionId(), dto);
+        }
+        return bySession.values().stream()
+                .sorted(Comparator.comparing(FeedbackListDto::createdAt).reversed())
+                .toList();
+    }
+
+    private FeedbackListDto toListDto(Interview interview, String overallScore) {
+        return FeedbackListDto.builder()
+                .sessionId(interview.getSessionId())
+                .category(interview.getCategory())
+                .overallScore(overallScore)
+                .createdAt(interview.getCreatedAt())
+                .build();
+    }
+
+    private FeedbackResponse buildFeedbackResponse(String rawFeedback, List<InterviewQna> qnas) {
         List<QAPair> qaPairs = qnas.stream()
                 .map(qna -> QAPair.builder()
                         .sequenceNumber(qna.getSequenceNumber())
@@ -59,54 +127,23 @@ public class FeedbackService {
                         .answerContent(parseAnswerSummary(qna))
                         .modelAnswer(qna.getModelAnswer())
                         .individualFeedback(qna.getIndividualFeedback())
-                        .isFollowUp(qna.isFollowUp()) // 엔티티의 메서드 사용
+                        .isFollowUp(qna.isFollowUp())
                         .parentSequenceNumber(qna.getParent() != null ? qna.getParent().getSequenceNumber() : null)
                         .build())
                 .toList();
 
-        // 5. 텍스트 데이터 가공 (차트 데이터 분리)
         String onlyChart = extractChartData(rawFeedback);
-        // [SCORE] 태그 앞부분만 피드백 본문으로 추출
         String onlyFeedback = rawFeedback.split("\n\n\\[SCORE\\]")[0];
 
-        // 6. 결과 반환 (DTO 포장)
         return FeedbackResponse.builder()
                 .success(true)
                 .totalFeedback(onlyFeedback)
                 .overallScore(extractOverallScore(rawFeedback))
-                .competencyChart(onlyChart) // 프론트 전달용 JSON 문자열
+                .competencyChart(onlyChart)
                 .qaPairs(qaPairs)
                 .build();
     }
 
-    // ──────────────────────────────────────────────────────────────────
-    // 면접 기록 목록 조회 (마이페이지)
-    // ──────────────────────────────────────────────────────────────────
-
-    /**
-     * 사용자의 면접 기록 목록 조회
-     */
-    @Transactional(readOnly = true)
-    public List<FeedbackListDto> getFeedbackList(String loginId) {
-        Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UnauthorizedException("회원 정보를 찾을 수 없습니다."));
-        // 면접 status가 COMPLETED인 상태만 조회
-        List<Interview> interviews = interviewRepository.findByMemberIdAndStatusOrderByCreatedAtDesc(member.getId(), InterviewStatus.COMPLETED);
-
-
-        return interviews.stream()
-                .map(interview -> FeedbackListDto.builder()
-                        .sessionId(interview.getSessionId())
-                        .category(interview.getCategory())
-                        .overallScore(extractOverallScore(interview.getTotalFeedback()))
-                        .createdAt(interview.getCreatedAt())
-                        .build())
-                .toList();
-    }
-
-    /**
-     * [competencyChart] (역량차트) 태그 뒤의 JSON 데이터를 추출하는 헬퍼 메서드
-     */
     private String extractChartData(String rawData) {
         if (rawData != null && rawData.contains("[CHART]")) {
             return rawData.substring(rawData.indexOf("[CHART]") + "[CHART]".length()).trim();
@@ -114,10 +151,6 @@ public class FeedbackService {
         return "{}";
     }
 
-    /**
-     * answerSummary(JSON 배열)를 파싱해 줄바꿈으로 이어붙인 문자열을 반환한다.
-     * answerSummary가 없으면 answerContent(STT 원문)로 폴백한다.
-     */
     private String parseAnswerSummary(InterviewQna qna) {
         String summary = qna.getAnswerSummary();
         if (summary == null || summary.isBlank()) {
@@ -139,9 +172,6 @@ public class FeedbackService {
         }
     }
 
-    /*
-    * [overallScore] 상중하 추출 메소드
-    * */
     private String extractOverallScore(String rawFeedback) {
         if (rawFeedback == null || !rawFeedback.contains("[SCORE]")) return null;
         int start = rawFeedback.indexOf("[SCORE]") + "[SCORE]\n".length();

--- a/src/main/java/com/capstone/interview/service/InternalQnaService.java
+++ b/src/main/java/com/capstone/interview/service/InternalQnaService.java
@@ -37,7 +37,12 @@ public class InternalQnaService {
                 .findByInterviewAndSequenceNumber(interview, request.turnNumber())
                 .orElse(null);
 
+        Long respondentId = resolveRespondentId(interview, request);
+
         if (existing != null) {
+            if (respondentId != null) {
+                existing.setRespondentMemberId(respondentId);
+            }
             if (request.question() != null) {
                 existing.updateQuestion(
                         request.question(),
@@ -73,6 +78,7 @@ public class InternalQnaService {
                     .answerSummary(toJson(request.answerSummary()))
                     .followUpDecision(request.followUpDecision())
                     .focusPoint(request.focusPoint())
+                    .respondentMemberId(respondentId)
                     .build();
             interviewQnaRepository.save(newQna);
             log.info("[QnA insert] created sessionId={}, turn={}", sessionId, request.turnNumber());
@@ -81,6 +87,19 @@ public class InternalQnaService {
         if (request.turnNumber() != null && request.answerSummary() != null) {
             eventPublisher.publishEvent(new QnaSavedEvent(sessionId, request.turnNumber()));
         }
+    }
+
+    private Long resolveRespondentId(Interview interview, InternalQnaRequest request) {
+        if (request.respondentMemberId() != null) {
+            return request.respondentMemberId();
+        }
+        if (!interview.isGroupMode() && interview.getMember() != null) {
+            return interview.getMember().getId();
+        }
+        if (interview.isGroupMode()) {
+            log.warn("[QnA upsert] group session missing respondentMemberId sessionId={}", interview.getSessionId());
+        }
+        return null;
     }
 
     private boolean hasAnswerAnalysis(InternalQnaRequest request) {

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -1,24 +1,12 @@
 package com.capstone.interview.service;
 
-import com.capstone.interview.dto.NextTurnRequest;
-import com.capstone.interview.dto.NextTurnResponse;
-import com.capstone.interview.dto.SessionCreateRequest;
-import com.capstone.interview.dto.SessionCreateResponse;
-import com.capstone.interview.dto.SessionEndResponse;
-import com.capstone.interview.entity.CoverLetter;
-import com.capstone.interview.entity.Interview;
-import com.capstone.interview.entity.InterviewQna;
-import com.capstone.interview.entity.InterviewStatus;
-import com.capstone.interview.entity.Member;
-import com.capstone.interview.entity.Resume;
+import com.capstone.interview.dto.*;
+import com.capstone.interview.entity.*;
+import com.capstone.interview.exception.ConflictException;
 import com.capstone.interview.exception.InvalidStateException;
 import com.capstone.interview.exception.SessionNotFoundException;
 import com.capstone.interview.exception.UnauthorizedException;
-import com.capstone.interview.repository.CoverLetterRepository;
-import com.capstone.interview.repository.InterviewQnaRepository;
-import com.capstone.interview.repository.InterviewRepository;
-import com.capstone.interview.repository.MemberRepository;
-import com.capstone.interview.repository.ResumeRepository;
+import com.capstone.interview.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -26,8 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -35,14 +22,15 @@ import java.util.UUID;
 public class InterviewService {
 
     private static final int ANSWER_TIME_LIMIT_SECONDS = 90;
+    private static final int MAX_GROUP_PARTICIPANTS = 4;
 
     private final InterviewRepository interviewRepository;
     private final InterviewQnaRepository interviewQnaRepository;
+    private final InterviewParticipantRepository participantRepository;
     private final MemberRepository memberRepository;
     private final ResumeRepository resumeRepository;
     private final CoverLetterRepository coverLetterRepository;
     private final LiveKitService liveKitService;
-    private final EvaluationService evaluationService;
     private final LiveKitRoomService liveKitRoomService;
     private final AgentDispatchService agentDispatchService;
 
@@ -52,87 +40,160 @@ public class InterviewService {
             throw new IllegalArgumentException("jobField와 durationMinutes는 필수입니다.");
         }
 
-        Resume resume = null;
-        if (request.resumeIds() != null) {
-            resume = resumeRepository.findById(request.resumeIds())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이력서입니다: " + request.resumeIds()));
-        }
+        int maxParticipants = normalizeMaxParticipants(request.maxParticipants());
+        Member host = currentMember();
 
-        CoverLetter coverLetter = null;
-        if (request.coverLetter() != null) {
-            coverLetter = coverLetterRepository.findById(request.coverLetter())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 자기소개서입니다: " + request.coverLetter()));
-        }
-
-        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UnauthorizedException("인증된 사용자를 찾을 수 없습니다."));
+        Resume resume = resolveResume(request.resumeIds());
+        CoverLetter coverLetter = resolveCoverLetter(request.coverLetter());
 
         String sessionId = "sess-" + UUID.randomUUID();
         String roomName = liveKitService.generateRoomName();
         int totalDurationSeconds = request.durationMinutes() * 60;
+        InterviewMode mode = maxParticipants > 1 ? InterviewMode.GROUP : InterviewMode.SOLO;
 
         Interview interview = Interview.builder()
-                .member(member)
+                .member(host)
                 .resume(resume)
                 .coverLetter(coverLetter)
                 .category(request.jobField())
                 .sessionId(sessionId)
                 .roomName(roomName)
                 .durationMinutes(request.durationMinutes())
+                .maxParticipants(maxParticipants)
+                .mode(mode)
                 .build();
+
+        if (mode == InterviewMode.GROUP) {
+            interview.enterWaitingLobby();
+            interviewRepository.save(interview);
+            InterviewParticipant hostParticipant = InterviewParticipant.builder()
+                    .interview(interview)
+                    .member(host)
+                    .role(ParticipantRole.HOST)
+                    .resume(resume)
+                    .ready(false)
+                    .build();
+            participantRepository.save(hostParticipant);
+
+            String token = liveKitService.generateToken(roomName, hostParticipant.liveKitIdentity());
+            return buildSessionResponse(interview, token, totalDurationSeconds);
+        }
 
         interview.start();
         interviewRepository.save(interview);
+        dispatchAgentAndInitTurn(interview, resume, coverLetter, request.jobField(),
+                totalDurationSeconds, List.of(hostParticipantMeta(host, resume)));
 
-        // Agent Dispatch
-        String resumeText = resume != null ? resume.getOriginalText() : "";
-        String coverLetterText = coverLetter != null ? coverLetter.getOriginalText() : "";
+        String token = liveKitService.generateToken(roomName, "user-" + host.getId());
+        return buildSessionResponse(interview, token, totalDurationSeconds);
+    }
 
-        try {
-            agentDispatchService.dispatch(
-                    roomName, sessionId, request.jobField(),
-                    resumeText, coverLetterText,
-                    totalDurationSeconds, ANSWER_TIME_LIMIT_SECONDS
-            );
-        } catch (Exception e) {
-            log.error("[세션 생성] Agent dispatch 실패, 세션을 FAILED 처리합니다. sessionId={}", sessionId, e);
-            interview.fail();
-            throw new RuntimeException("Agent dispatch에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    @Transactional
+    public JoinSessionResponse joinSession(String sessionId, JoinSessionRequest request) {
+        Interview interview = findInterviewOrThrow(sessionId);
+        if (interview.getStatus() != InterviewStatus.WAITING) {
+            throw new InvalidStateException("WAITING 상태의 세션만 입장할 수 있습니다. 현재: " + interview.getStatus());
+        }
+        if (!interview.isGroupMode()) {
+            throw new InvalidStateException("그룹 면접 세션만 입장할 수 있습니다.");
         }
 
-        // 첫 턴 초기화 (turnNumber=1)
-        LocalDateTime now = LocalDateTime.now();
-        InterviewQna firstTurn = InterviewQna.builder()
+        Member member = currentMember();
+        if (interview.getMember() != null && interview.getMember().getId().equals(member.getId())) {
+            throw new ConflictException("호스트는 이미 세션에 참여 중입니다. 대기실로 이동하세요.");
+        }
+
+        Optional<InterviewParticipant> existing = participantRepository.findByInterviewAndMember(interview, member);
+        if (existing.isPresent()) {
+            InterviewParticipant p = existing.get();
+            String token = liveKitService.generateToken(interview.getRoomName(), p.liveKitIdentity());
+            return buildJoinResponse(interview, p, token);
+        }
+
+        long count = participantRepository.countByInterview(interview);
+        if (count >= interview.getMaxParticipants()) {
+            throw new ConflictException("면접 정원이 가득 찼습니다.");
+        }
+
+        Resume resume = null;
+        if (request != null && request.resumeId() != null) {
+            resume = resumeRepository.findById(request.resumeId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이력서입니다: " + request.resumeId()));
+        }
+
+        InterviewParticipant guest = InterviewParticipant.builder()
                 .interview(interview)
-                .sequenceNumber(1)
-                .questionContent("")
-                .answerContent("")
-                .startedAt(now)
-                .expiresAt(now.plusSeconds(ANSWER_TIME_LIMIT_SECONDS))
+                .member(member)
+                .role(ParticipantRole.GUEST)
+                .resume(resume)
+                .ready(false)
                 .build();
-        interviewQnaRepository.save(firstTurn);
+        participantRepository.save(guest);
 
-        String token = liveKitService.generateToken(roomName, "user-" + member.getId());
+        String token = liveKitService.generateToken(interview.getRoomName(), guest.liveKitIdentity());
+        return buildJoinResponse(interview, guest, token);
+    }
 
-        return new SessionCreateResponse(
+    @Transactional(readOnly = true)
+    public LobbyResponse getLobby(String sessionId) {
+        Interview interview = findInterviewOrThrow(sessionId);
+        Member member = currentMember();
+        InterviewParticipant me = findParticipantOrThrow(interview, member);
+
+        List<InterviewParticipant> participants = participantRepository.findByInterviewOrderByJoinedAtAsc(interview);
+        long readyCount = participantRepository.countByInterviewAndReadyTrue(interview);
+        int currentCount = participants.size();
+        boolean allReady = readyCount == interview.getMaxParticipants()
+                && currentCount == interview.getMaxParticipants();
+
+        String token = liveKitService.generateToken(interview.getRoomName(), me.liveKitIdentity());
+
+        return new LobbyResponse(
                 true,
-                new SessionCreateResponse.Data(
-                        sessionId,
-                        new SessionCreateResponse.LiveKitInfo(roomName, liveKitService.getUrl(), token),
-                        ANSWER_TIME_LIMIT_SECONDS,
-                        totalDurationSeconds
+                new LobbyResponse.Data(
+                        interview.getSessionId(),
+                        interview.getStatus().name(),
+                        interview.getMode().name(),
+                        interview.getMaxParticipants(),
+                        currentCount,
+                        (int) readyCount,
+                        allReady,
+                        me.getRole().name(),
+                        me.liveKitIdentity(),
+                        me.isReady(),
+                        toParticipantDtos(participants),
+                        new SessionCreateResponse.LiveKitInfo(
+                                interview.getRoomName(),
+                                liveKitService.getUrl(),
+                                token
+                        )
                 )
         );
     }
 
     @Transactional
+    public LobbyResponse setReady(String sessionId) {
+        Interview interview = findInterviewOrThrow(sessionId);
+        if (interview.getStatus() != InterviewStatus.WAITING) {
+            throw new InvalidStateException("WAITING 상태에서만 준비할 수 있습니다. 현재: " + interview.getStatus());
+        }
+
+        Member member = currentMember();
+        InterviewParticipant me = findParticipantOrThrow(interview, member);
+        me.markReady();
+        participantRepository.save(me);
+
+        tryAutoStart(interview);
+
+        return getLobby(sessionId);
+    }
+
+    @Transactional
     public NextTurnResponse nextTurn(String sessionId, NextTurnRequest request) {
         Interview interview = findInterviewOrThrow(sessionId);
-        verifyOwner(interview);
+        verifyHost(interview);
         verifyInProgress(interview);
 
-        // 현재 턴 번호 검증
         int currentTurn = interviewQnaRepository.countByInterview(interview);
         if (request.currentTurnNumber() != null && !request.currentTurnNumber().equals(currentTurn)) {
             log.warn("[/next] 턴 번호 불일치. 클라이언트={}, 서버={}", request.currentTurnNumber(), currentTurn);
@@ -142,7 +203,11 @@ public class InterviewService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime expiresAt = now.plusSeconds(ANSWER_TIME_LIMIT_SECONDS);
 
-        // 다음 턴 레코드 생성
+        Long speakerId = interview.getCurrentSpeakerMemberId();
+        if (speakerId == null && interview.getMember() != null) {
+            speakerId = interview.getMember().getId();
+        }
+
         InterviewQna nextQna = InterviewQna.builder()
                 .interview(interview)
                 .sequenceNumber(nextTurnNumber)
@@ -150,19 +215,23 @@ public class InterviewService {
                 .answerContent("")
                 .startedAt(now)
                 .expiresAt(expiresAt)
+                .respondentMemberId(speakerId)
                 .build();
         interviewQnaRepository.save(nextQna);
 
-        // Agent 에 NEXT Data Message 전송 — 실패 시 롤백
         try {
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("turnNumber", nextTurnNumber);
+            if (speakerId != null) {
+                payload.put("targetIdentity", "user-" + speakerId);
+            }
             Map<String, Object> message = Map.of(
                     "type", "NEXT",
-                    "payload", Map.of("turnNumber", nextTurnNumber)
+                    "payload", payload
             );
             liveKitRoomService.sendData(interview.getRoomName(), message);
         } catch (Exception e) {
             log.error("[/next] sendData 실패, 턴 증가를 롤백합니다. sessionId={}", sessionId, e);
-            // 롤백: 방금 생성한 턴 레코드 삭제
             interviewQnaRepository.delete(nextQna);
             throw new RuntimeException("Agent에 다음 질문 신호 전송에 실패했습니다. 다시 시도해주세요.");
         }
@@ -176,10 +245,13 @@ public class InterviewService {
     @Transactional
     public SessionEndResponse endSession(String sessionId, String reason) {
         Interview interview = findInterviewOrThrow(sessionId);
-        verifyOwner(interview);
+        if (interview.isGroupMode()) {
+            verifyHost(interview);
+        } else {
+            verifyOwner(interview);
+        }
         verifyInProgress(interview);
 
-        // 1. Agent 에 END 메시지 전송 (실패해도 계속 진행)
         try {
             Map<String, Object> message = Map.of(
                     "type", "END",
@@ -190,15 +262,9 @@ public class InterviewService {
             log.warn("[/end] sendData(END) 실패, deleteRoom으로 정리합니다. sessionId={}", sessionId);
         }
 
-        // 2. Room 삭제 — Agent 강제 연결 종료
         liveKitRoomService.deleteRoom(interview.getRoomName());
-
-        // 3. 세션 상태 COMPLETED 전환
         interview.complete();
         interviewRepository.save(interview);
-
-        // EvaluationService 비동기 호출 (삭제)
-        //evaluationService.evaluate(sessionId);
 
         return new SessionEndResponse(
                 true,
@@ -207,9 +273,233 @@ public class InterviewService {
         );
     }
 
+    @Transactional
+    protected void tryAutoStart(Interview interview) {
+        if (interview.getStatus() != InterviewStatus.WAITING) {
+            return;
+        }
+
+        long readyCount = participantRepository.countByInterviewAndReadyTrue(interview);
+        long participantCount = participantRepository.countByInterview(interview);
+        if (readyCount < interview.getMaxParticipants()
+                || participantCount < interview.getMaxParticipants()) {
+            return;
+        }
+
+        List<InterviewParticipant> participants =
+                participantRepository.findByInterviewOrderByJoinedAtAsc(interview);
+        InterviewParticipant firstSpeaker = participants.get(0);
+        interview.setCurrentSpeakerMemberId(firstSpeaker.getMember().getId());
+        interview.start();
+        interviewRepository.save(interview);
+
+        List<Map<String, Object>> participantMeta = buildParticipantMetadata(participants);
+        String resumeText = interview.getResume() != null ? interview.getResume().getOriginalText() : "";
+        String coverLetterText = interview.getCoverLetter() != null
+                ? interview.getCoverLetter().getOriginalText() : "";
+
+        try {
+            agentDispatchService.dispatchGroup(
+                    interview.getRoomName(),
+                    interview.getSessionId(),
+                    interview.getCategory(),
+                    resumeText,
+                    coverLetterText,
+                    interview.getDurationMinutes() * 60,
+                    ANSWER_TIME_LIMIT_SECONDS,
+                    interview.getMaxParticipants(),
+                    participantMeta
+            );
+        } catch (Exception e) {
+            log.error("[그룹 시작] Agent dispatch 실패 sessionId={}", interview.getSessionId(), e);
+            interview.fail();
+            interviewRepository.save(interview);
+            throw new RuntimeException("Agent dispatch에 실패했습니다. 잠시 후 다시 시도해주세요.");
+        }
+
+        initFirstTurn(interview, firstSpeaker.getMember().getId());
+        sendStartData(interview, participants, firstSpeaker);
+    }
+
+    private void dispatchAgentAndInitTurn(Interview interview, Resume resume, CoverLetter coverLetter,
+                                          String jobField, int totalDurationSeconds,
+                                          List<Map<String, Object>> participantMeta) {
+        String resumeText = resume != null ? resume.getOriginalText() : "";
+        String coverLetterText = coverLetter != null ? coverLetter.getOriginalText() : "";
+
+        try {
+            if (interview.isGroupMode()) {
+                agentDispatchService.dispatchGroup(
+                        interview.getRoomName(), interview.getSessionId(), jobField,
+                        resumeText, coverLetterText, totalDurationSeconds,
+                        ANSWER_TIME_LIMIT_SECONDS, interview.getMaxParticipants(), participantMeta);
+            } else {
+                agentDispatchService.dispatch(
+                        interview.getRoomName(), interview.getSessionId(), jobField,
+                        resumeText, coverLetterText, totalDurationSeconds, ANSWER_TIME_LIMIT_SECONDS);
+            }
+        } catch (Exception e) {
+            log.error("[세션 생성] Agent dispatch 실패 sessionId={}", interview.getSessionId(), e);
+            interview.fail();
+            throw new RuntimeException("Agent dispatch에 실패했습니다. 잠시 후 다시 시도해주세요.");
+        }
+
+        Long respondentId = interview.getMember() != null ? interview.getMember().getId() : null;
+        initFirstTurn(interview, respondentId);
+    }
+
+    private void initFirstTurn(Interview interview, Long respondentMemberId) {
+        LocalDateTime now = LocalDateTime.now();
+        InterviewQna firstTurn = InterviewQna.builder()
+                .interview(interview)
+                .sequenceNumber(1)
+                .questionContent("")
+                .answerContent("")
+                .startedAt(now)
+                .expiresAt(now.plusSeconds(ANSWER_TIME_LIMIT_SECONDS))
+                .respondentMemberId(respondentMemberId)
+                .build();
+        interviewQnaRepository.save(firstTurn);
+    }
+
+    private void sendStartData(Interview interview, List<InterviewParticipant> participants,
+                               InterviewParticipant firstSpeaker) {
+        List<Map<String, Object>> payloadParticipants = participants.stream()
+                .map(p -> Map.<String, Object>of(
+                        "memberId", p.getMember().getId(),
+                        "identity", p.liveKitIdentity(),
+                        "name", p.getMember().getName()
+                ))
+                .toList();
+
+        Map<String, Object> message = Map.of(
+                "type", "START",
+                "payload", Map.of(
+                        "participants", payloadParticipants,
+                        "currentSpeakerIndex", 0,
+                        "targetIdentity", firstSpeaker.liveKitIdentity()
+                )
+        );
+        try {
+            liveKitRoomService.sendData(interview.getRoomName(), message);
+        } catch (Exception e) {
+            log.warn("[START] sendData 실패 sessionId={}", interview.getSessionId(), e);
+        }
+    }
+
+    private List<Map<String, Object>> buildParticipantMetadata(List<InterviewParticipant> participants) {
+        List<Map<String, Object>> meta = new ArrayList<>();
+        for (InterviewParticipant p : participants) {
+            String resumeText = p.getResume() != null ? p.getResume().getOriginalText() : "";
+            if (resumeText.isBlank() && p.getRole() == ParticipantRole.HOST
+                    && p.getInterview().getResume() != null) {
+                resumeText = p.getInterview().getResume().getOriginalText();
+            }
+            meta.add(Map.of(
+                    "memberId", p.getMember().getId(),
+                    "identity", p.liveKitIdentity(),
+                    "name", p.getMember().getName(),
+                    "resumeText", resumeText != null ? resumeText : ""
+            ));
+        }
+        return meta;
+    }
+
+    private Map<String, Object> hostParticipantMeta(Member host, Resume resume) {
+        return Map.of(
+                "memberId", host.getId(),
+                "identity", "user-" + host.getId(),
+                "name", host.getName(),
+                "resumeText", resume != null && resume.getOriginalText() != null ? resume.getOriginalText() : ""
+        );
+    }
+
+    private SessionCreateResponse buildSessionResponse(Interview interview, String token, int totalDurationSeconds) {
+        return new SessionCreateResponse(
+                true,
+                new SessionCreateResponse.Data(
+                        interview.getSessionId(),
+                        new SessionCreateResponse.LiveKitInfo(
+                                interview.getRoomName(),
+                                liveKitService.getUrl(),
+                                token
+                        ),
+                        ANSWER_TIME_LIMIT_SECONDS,
+                        totalDurationSeconds,
+                        interview.getMode().name(),
+                        interview.getMaxParticipants(),
+                        interview.getStatus().name()
+                )
+        );
+    }
+
+    private JoinSessionResponse buildJoinResponse(Interview interview, InterviewParticipant participant, String token) {
+        return new JoinSessionResponse(
+                true,
+                new JoinSessionResponse.Data(
+                        interview.getSessionId(),
+                        new SessionCreateResponse.LiveKitInfo(
+                                interview.getRoomName(),
+                                liveKitService.getUrl(),
+                                token
+                        ),
+                        interview.getMode().name(),
+                        interview.getStatus().name(),
+                        participant.getRole().name(),
+                        participant.liveKitIdentity(),
+                        interview.getMaxParticipants()
+                )
+        );
+    }
+
+    private List<ParticipantDto> toParticipantDtos(List<InterviewParticipant> participants) {
+        return participants.stream()
+                .map(p -> new ParticipantDto(
+                        p.getMember().getId(),
+                        p.getMember().getName(),
+                        p.getMember().getLoginId(),
+                        p.getRole().name(),
+                        p.isReady(),
+                        p.liveKitIdentity()
+                ))
+                .toList();
+    }
+
+    private int normalizeMaxParticipants(Integer maxParticipants) {
+        int value = maxParticipants != null ? maxParticipants : 1;
+        if (value < 1 || value > MAX_GROUP_PARTICIPANTS) {
+            throw new IllegalArgumentException(
+                    "maxParticipants는 1~" + MAX_GROUP_PARTICIPANTS + " 사이여야 합니다.");
+        }
+        return value;
+    }
+
+    private Resume resolveResume(Long resumeId) {
+        if (resumeId == null) return null;
+        return resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이력서입니다: " + resumeId));
+    }
+
+    private CoverLetter resolveCoverLetter(Long coverLetterId) {
+        if (coverLetterId == null) return null;
+        return coverLetterRepository.findById(coverLetterId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 자기소개서입니다: " + coverLetterId));
+    }
+
+    private Member currentMember() {
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
+        return memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UnauthorizedException("인증된 사용자를 찾을 수 없습니다."));
+    }
+
     private Interview findInterviewOrThrow(String sessionId) {
         return interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new SessionNotFoundException("존재하지 않는 세션입니다: " + sessionId));
+    }
+
+    private InterviewParticipant findParticipantOrThrow(Interview interview, Member member) {
+        return participantRepository.findByInterviewAndMember(interview, member)
+                .orElseThrow(() -> new UnauthorizedException("이 면접 세션의 참가자가 아닙니다."));
     }
 
     private void verifyOwner(Interview interview) {
@@ -217,6 +507,14 @@ public class InterviewService {
         Member member = interview.getMember();
         if (member == null || !member.getLoginId().equals(loginId)) {
             throw new UnauthorizedException("본인의 면접 세션만 제어할 수 있습니다.");
+        }
+    }
+
+    private void verifyHost(Interview interview) {
+        Member member = currentMember();
+        InterviewParticipant participant = findParticipantOrThrow(interview, member);
+        if (participant.getRole() != ParticipantRole.HOST) {
+            throw new UnauthorizedException("호스트만 이 작업을 수행할 수 있습니다.");
         }
     }
 
@@ -236,11 +534,23 @@ public class InterviewService {
         Interview interview = findInterviewOrThrow(sessionId);
         verifyOwner(interview);
 
-        // QnA 데이터 먼저 삭제
         interviewQnaRepository.deleteAllByInterview(interview);
-
-        // 면접 기록 삭제
         interviewRepository.delete(interview);
         log.info("[면접 기록 삭제] sessionId={}", sessionId);
+    }
+
+    public Interview findInterviewForFeedback(String sessionId) {
+        return findInterviewOrThrow(sessionId);
+    }
+
+    public InterviewParticipant findParticipantForMember(Interview interview, Member member) {
+        if (interview.isGroupMode()) {
+            return findParticipantOrThrow(interview, member);
+        }
+        return null;
+    }
+
+    public Member getCurrentMember() {
+        return currentMember();
     }
 }

--- a/src/test/java/com/capstone/interview/service/EvaluationFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/EvaluationFlowTest.java
@@ -5,8 +5,10 @@ import com.capstone.interview.config.LLMClient;
 import com.capstone.interview.dto.FeedbackListDto;
 import com.capstone.interview.dto.FeedbackResponse;
 import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.InterviewMode;
 import com.capstone.interview.entity.InterviewQna;
 import com.capstone.interview.entity.Member;
+import com.capstone.interview.repository.InterviewParticipantRepository;
 import com.capstone.interview.repository.InterviewQnaRepository;
 import com.capstone.interview.repository.InterviewRepository;
 import com.capstone.interview.repository.MemberRepository;
@@ -31,6 +33,7 @@ class EvaluationFlowTest {
     private static FeedbackService feedbackService;
     private static InterviewRepository interviewRepository;
     private static InterviewQnaRepository interviewQnaRepository;
+    private static InterviewParticipantRepository participantRepository;
     private static MemberRepository memberRepository;
     private static Interview testInterview;
     private static List<InterviewQna> testQnas;
@@ -41,14 +44,15 @@ class EvaluationFlowTest {
 
         interviewRepository = mock(InterviewRepository.class);
         interviewQnaRepository = mock(InterviewQnaRepository.class);
+        participantRepository = mock(InterviewParticipantRepository.class);
         memberRepository = mock(MemberRepository.class);
         LLMClient llmClient = new MockLLMClient();
         ObjectMapper objectMapper = new ObjectMapper();
 
         evaluationService = new EvaluationService(
-                interviewRepository, interviewQnaRepository, llmClient, objectMapper);
+                interviewRepository, interviewQnaRepository, participantRepository, llmClient, objectMapper);
         feedbackService = new FeedbackService(
-                interviewRepository, interviewQnaRepository, memberRepository, objectMapper);
+                interviewRepository, interviewQnaRepository, participantRepository, memberRepository, objectMapper);
 
         Member member = createMember(1L, "test1", "Tester");
         testInterview = createInterview(1L, "sess-test-0001", member, "BACKEND");
@@ -123,7 +127,7 @@ class EvaluationFlowTest {
 
         System.out.println("\n=== Stage 2: FeedbackService.getFeedback() ===");
 
-        FeedbackResponse response = feedbackService.getFeedback("sess-test-0001");
+        FeedbackResponse response = feedbackService.getFeedback("sess-test-0001", "test1");
 
         System.out.println("[Output] FeedbackResponse:");
         System.out.println("  success: " + response.isSuccess());
@@ -182,7 +186,12 @@ class EvaluationFlowTest {
 
     private static Interview createInterview(Long id, String sessionId, Member member, String category) throws Exception {
         Interview interview = Interview.builder()
-                .member(member).category(category).sessionId(sessionId).build();
+                .member(member)
+                .category(category)
+                .sessionId(sessionId)
+                .maxParticipants(1)
+                .mode(InterviewMode.SOLO)
+                .build();
         interview.start();
         setField(interview, "id", id);
         setField(interview, "createdAt", LocalDateTime.now());

--- a/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
@@ -1,0 +1,125 @@
+package com.capstone.interview.service;
+
+import com.capstone.interview.dto.*;
+import com.capstone.interview.entity.*;
+import com.capstone.interview.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GroupInterviewFlowTest {
+
+    @Mock InterviewRepository interviewRepository;
+    @Mock InterviewQnaRepository interviewQnaRepository;
+    @Mock InterviewParticipantRepository participantRepository;
+    @Mock MemberRepository memberRepository;
+    @Mock ResumeRepository resumeRepository;
+    @Mock CoverLetterRepository coverLetterRepository;
+    @Mock LiveKitService liveKitService;
+    @Mock LiveKitRoomService liveKitRoomService;
+    @Mock AgentDispatchService agentDispatchService;
+
+    @InjectMocks InterviewService interviewService;
+
+    private Member host;
+    private Member guest;
+
+    @BeforeEach
+    void setUp() {
+        host = Member.builder().loginId("host").password("p").name("Host").build();
+        setId(host, 1L);
+        guest = Member.builder().loginId("guest").password("p").name("Guest").build();
+        setId(guest, 2L);
+
+        when(liveKitService.generateRoomName()).thenReturn("room-test");
+        when(liveKitService.getUrl()).thenReturn("wss://test");
+        when(liveKitService.generateToken(anyString(), anyString())).thenReturn("token");
+    }
+
+    @Test
+    void createGroupSession_staysWaitingWithoutDispatch() {
+        loginAs(host);
+        when(memberRepository.findByLoginId("host")).thenReturn(Optional.of(host));
+        when(interviewRepository.save(any())).thenAnswer(inv -> {
+            Interview i = inv.getArgument(0);
+            setId(i, 10L);
+            return i;
+        });
+        when(participantRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        SessionCreateResponse response = interviewService.createSession(
+                new SessionCreateRequest(null, null, "BACKEND", 15, 2));
+
+        assertEquals("WAITING", response.data().status());
+        assertEquals("GROUP", response.data().mode());
+        assertEquals(2, response.data().maxParticipants());
+        verify(agentDispatchService, never()).dispatchGroup(any(), any(), any(), any(), any(), anyInt(), anyInt(), anyInt(), anyList());
+    }
+
+    @Test
+    void autoStart_whenAllReady() {
+        Interview interview = Interview.builder()
+                .member(host)
+                .category("BACKEND")
+                .sessionId("sess-group-1")
+                .roomName("room-1")
+                .durationMinutes(15)
+                .maxParticipants(2)
+                .mode(InterviewMode.GROUP)
+                .build();
+        interview.enterWaitingLobby();
+        setId(interview, 10L);
+
+        InterviewParticipant hostP = InterviewParticipant.builder()
+                .interview(interview).member(host).role(ParticipantRole.HOST).ready(false).build();
+        InterviewParticipant guestP = InterviewParticipant.builder()
+                .interview(interview).member(guest).role(ParticipantRole.GUEST).ready(false).build();
+
+        loginAs(host);
+        when(memberRepository.findByLoginId("host")).thenReturn(Optional.of(host));
+        when(interviewRepository.findBySessionId("sess-group-1")).thenReturn(Optional.of(interview));
+        when(participantRepository.findByInterviewAndMember(interview, host)).thenReturn(Optional.of(hostP));
+        when(participantRepository.findByInterviewOrderByJoinedAtAsc(interview))
+                .thenReturn(java.util.List.of(hostP, guestP));
+        when(participantRepository.countByInterviewAndReadyTrue(interview)).thenReturn(2L);
+        when(participantRepository.countByInterview(interview)).thenReturn(2L);
+        when(interviewRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(interviewQnaRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        LobbyResponse lobby = interviewService.setReady("sess-group-1");
+
+        assertEquals("IN_PROGRESS", lobby.data().status());
+        verify(agentDispatchService).dispatchGroup(any(), eq("sess-group-1"), any(), any(), any(), anyInt(), anyInt(), eq(2), anyList());
+        verify(liveKitRoomService).sendData(eq("room-1"), argThat(m -> "START".equals(m.get("type"))));
+    }
+
+    private void loginAs(Member member) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(member.getLoginId(), null));
+    }
+
+    private static void setId(Object entity, Long id) {
+        try {
+            var f = entity.getClass().getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- SOLO/GROUP 면접 모드 지원
- GROUP 모드: 세션 생성 → join → lobby → 시작 흐름 추가
- 참가자별 QnA/피드백 및 EvaluationService 확장
- prod용 수동 마이그레이션 SQL 포함 (`scripts/add-group-interview-support.sql`)

## DB 주의사항
- prod 프로파일은 `ddl-auto: validate` 이므로 **RDS에 SQL 수동 적용 필요**
- RDS에는 이미 마이그레이션 적용 완료

## Test plan
- [x] `./gradlew build -x test` 성공
- [x] GroupInterviewFlowTest 포함
- [x] RDS 마이그레이션 적용 확인

Made with [Cursor](https://cursor.com)