### PR TITLE
[feat] 그룹면접 데이터 메시지 계약 정리

### DIFF
--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -203,11 +203,6 @@ public class InterviewService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime expiresAt = now.plusSeconds(ANSWER_TIME_LIMIT_SECONDS);
 
-        Long speakerId = interview.getCurrentSpeakerMemberId();
-        if (speakerId == null && interview.getMember() != null) {
-            speakerId = interview.getMember().getId();
-        }
-
         InterviewQna nextQna = InterviewQna.builder()
                 .interview(interview)
                 .sequenceNumber(nextTurnNumber)
@@ -215,19 +210,13 @@ public class InterviewService {
                 .answerContent("")
                 .startedAt(now)
                 .expiresAt(expiresAt)
-                .respondentMemberId(speakerId)
                 .build();
         interviewQnaRepository.save(nextQna);
 
         try {
-            Map<String, Object> payload = new LinkedHashMap<>();
-            payload.put("turnNumber", nextTurnNumber);
-            if (speakerId != null) {
-                payload.put("targetIdentity", "user-" + speakerId);
-            }
             Map<String, Object> message = Map.of(
                     "type", "NEXT",
-                    "payload", payload
+                    "payload", Map.of("turnNumber", nextTurnNumber)
             );
             liveKitRoomService.sendData(interview.getRoomName(), message);
         } catch (Exception e) {
@@ -288,8 +277,6 @@ public class InterviewService {
 
         List<InterviewParticipant> participants =
                 participantRepository.findByInterviewOrderByJoinedAtAsc(interview);
-        InterviewParticipant firstSpeaker = participants.get(0);
-        interview.setCurrentSpeakerMemberId(firstSpeaker.getMember().getId());
         interview.start();
         interviewRepository.save(interview);
 
@@ -317,8 +304,8 @@ public class InterviewService {
             throw new RuntimeException("Agent dispatch에 실패했습니다. 잠시 후 다시 시도해주세요.");
         }
 
-        initFirstTurn(interview, firstSpeaker.getMember().getId());
-        sendStartData(interview, participants, firstSpeaker);
+        initFirstTurn(interview, null);
+        sendStartData(interview);
     }
 
     private void dispatchAgentAndInitTurn(Interview interview, Resume resume, CoverLetter coverLetter,
@@ -362,24 +349,8 @@ public class InterviewService {
         interviewQnaRepository.save(firstTurn);
     }
 
-    private void sendStartData(Interview interview, List<InterviewParticipant> participants,
-                               InterviewParticipant firstSpeaker) {
-        List<Map<String, Object>> payloadParticipants = participants.stream()
-                .map(p -> Map.<String, Object>of(
-                        "memberId", p.getMember().getId(),
-                        "identity", p.liveKitIdentity(),
-                        "name", p.getMember().getName()
-                ))
-                .toList();
-
-        Map<String, Object> message = Map.of(
-                "type", "START",
-                "payload", Map.of(
-                        "participants", payloadParticipants,
-                        "currentSpeakerIndex", 0,
-                        "targetIdentity", firstSpeaker.liveKitIdentity()
-                )
-        );
+    private void sendStartData(Interview interview) {
+        Map<String, Object> message = Map.of("type", "START");
         try {
             liveKitRoomService.sendData(interview.getRoomName(), message);
         } catch (Exception e) {

--- a/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
@@ -105,7 +105,8 @@ class GroupInterviewFlowTest {
 
         assertEquals("IN_PROGRESS", lobby.data().status());
         verify(agentDispatchService).dispatchGroup(any(), eq("sess-group-1"), any(), any(), any(), anyInt(), anyInt(), eq(2), anyList());
-        verify(liveKitRoomService).sendData(eq("room-1"), argThat(m -> "START".equals(m.get("type"))));
+        verify(liveKitRoomService).sendData(eq("room-1"), argThat(m ->
+                "START".equals(m.get("type")) && !m.containsKey("payload")));
     }
 
     private void loginAs(Member member) {


### PR DESCRIPTION
## 관련 Issue
- closes #이슈번호

## 변경 사항
- 최신 main의 그룹면접 구현을 기준으로 PR 브랜치를 재기반화해 대량 충돌을 제거했습니다.
- Backend가 `START` Data Message를 시작 신호로만 보내도록 `payload`를 제거했습니다.
- Backend가 `NEXT` Data Message에 다음 `turnNumber`만 보내도록 `targetIdentity` 전송을 제거했습니다.
- 그룹면접 첫 턴/다음 턴의 응답자를 Backend가 선점하지 않도록 placeholder QnA의 `respondentMemberId` 자동 지정도 제거했습니다.
- START 메시지가 payload 없이 발송되는지 테스트를 보강했습니다.

## 접근 방식
- #53으로 main에 이미 반영된 그룹면접 로비/참가자/dispatch 구현은 유지했습니다.
- Agent가 첫 화자와 다음 화자를 직접 정하고 `QUESTION.targetIdentity`로 알려준다는 계약에 맞춰 Backend의 화자 지정 로직만 걷어냈습니다.

## AI 사용 내역
- PR 충돌 원인을 분석하고 최신 main 기준으로 변경 범위를 최소화하는 데 AI를 사용했습니다.
- 변경 후 Gradle 테스트로 직접 확인했습니다.

## 테스트
- `./gradlew test --rerun-tasks`

## 머지 전 체크리스트
- [x] PR description을 형식대로 작성했는가
- [ ] 최소 1명의 Approve를 받았는가
- [ ] blocker 코멘트가 모두 해결되었는가
- [x] 테스트가 통과하는가
- [x] 불필요한 console.log/디버그 코드가 제거되었는가