### PR TITLE
[fix] 단독 면접 참가자 저장 누락 수정

### DIFF
--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -66,14 +66,7 @@ public class InterviewService {
         if (mode == InterviewMode.GROUP) {
             interview.enterWaitingLobby();
             interviewRepository.save(interview);
-            InterviewParticipant hostParticipant = InterviewParticipant.builder()
-                    .interview(interview)
-                    .member(host)
-                    .role(ParticipantRole.HOST)
-                    .resume(resume)
-                    .ready(false)
-                    .build();
-            participantRepository.save(hostParticipant);
+            InterviewParticipant hostParticipant = saveHostParticipant(interview, host, resume);
 
             String token = liveKitService.generateToken(roomName, hostParticipant.liveKitIdentity());
             return buildSessionResponse(interview, token, totalDurationSeconds);
@@ -81,10 +74,11 @@ public class InterviewService {
 
         interview.start();
         interviewRepository.save(interview);
+        InterviewParticipant hostParticipant = saveHostParticipant(interview, host, resume);
         dispatchAgentAndInitTurn(interview, resume, coverLetter, request.jobField(),
-                totalDurationSeconds, List.of(hostParticipantMeta(host, resume)));
+                totalDurationSeconds, List.of(participantMeta(hostParticipant)));
 
-        String token = liveKitService.generateToken(roomName, "user-" + host.getId());
+        String token = liveKitService.generateToken(roomName, hostParticipant.liveKitIdentity());
         return buildSessionResponse(interview, token, totalDurationSeconds);
     }
 
@@ -376,10 +370,23 @@ public class InterviewService {
         return meta;
     }
 
-    private Map<String, Object> hostParticipantMeta(Member host, Resume resume) {
+    private InterviewParticipant saveHostParticipant(Interview interview, Member host, Resume resume) {
+        InterviewParticipant hostParticipant = InterviewParticipant.builder()
+                .interview(interview)
+                .member(host)
+                .role(ParticipantRole.HOST)
+                .resume(resume)
+                .ready(false)
+                .build();
+        return participantRepository.save(hostParticipant);
+    }
+
+    private Map<String, Object> participantMeta(InterviewParticipant participant) {
+        Member host = participant.getMember();
+        Resume resume = participant.getResume();
         return Map.of(
                 "memberId", host.getId(),
-                "identity", "user-" + host.getId(),
+                "identity", participant.liveKitIdentity(),
                 "name", host.getName(),
                 "resumeText", resume != null && resume.getOriginalText() != null ? resume.getOriginalText() : ""
         );

--- a/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
@@ -72,6 +72,35 @@ class GroupInterviewFlowTest {
     }
 
     @Test
+    void createSoloSession_savesHostParticipantBeforeDispatch() {
+        loginAs(host);
+        when(memberRepository.findByLoginId("host")).thenReturn(Optional.of(host));
+        when(interviewRepository.save(any())).thenAnswer(inv -> {
+            Interview i = inv.getArgument(0);
+            setId(i, 11L);
+            return i;
+        });
+        when(participantRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(interviewQnaRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        SessionCreateResponse response = interviewService.createSession(
+                new SessionCreateRequest(null, null, "BACKEND", 15, 1));
+
+        assertEquals("IN_PROGRESS", response.data().status());
+        assertEquals("SOLO", response.data().mode());
+        assertEquals(1, response.data().maxParticipants());
+        verify(participantRepository).save(argThat(participant ->
+                participant.getInterview().getId().equals(11L)
+                        && participant.getMember().getId().equals(host.getId())
+                        && participant.getRole() == ParticipantRole.HOST));
+
+        var order = inOrder(participantRepository, agentDispatchService);
+        order.verify(participantRepository).save(any(InterviewParticipant.class));
+        order.verify(agentDispatchService).dispatch(
+                eq("room-test"), anyString(), eq("BACKEND"), anyString(), anyString(), eq(900), anyInt());
+    }
+
+    @Test
     void autoStart_whenAllReady() {
         Interview interview = Interview.builder()
                 .member(host)


### PR DESCRIPTION
## 변경 내용
- SOLO 면접 세션 생성 시 HOST 참가자 레코드를 저장하도록 수정
- 참가자 저장 후 agent dispatch가 실행되는 회귀 테스트 추가

## 원인
- GROUP 생성 경로만 interview_participants에 HOST를 저장하고 SOLO 생성 경로는 저장하지 않아 /next 권한 검증에서 실패했습니다.

## 검증
- .\gradlew test