### PR TITLE
[Fix] 그룹면접 현재 화자 권한 처리

### DIFF
--- a/scripts/add-group-interview-support.sql
+++ b/scripts/add-group-interview-support.sql
@@ -16,10 +16,13 @@ CREATE TABLE IF NOT EXISTS interview_participants (
     resume_id BIGINT REFERENCES resumes(id),
     total_feedback TEXT,
     overall_score VARCHAR(20),
+    left_at TIMESTAMP,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,
     CONSTRAINT uk_interview_participant UNIQUE (interview_id, member_id)
 );
+
+ALTER TABLE interview_participants ADD COLUMN IF NOT EXISTS left_at TIMESTAMP;
 
 CREATE INDEX IF NOT EXISTS idx_interview_participants_interview ON interview_participants(interview_id);
 CREATE INDEX IF NOT EXISTS idx_interview_participants_member ON interview_participants(member_id);

--- a/src/main/java/com/capstone/interview/controller/InternalQnaController.java
+++ b/src/main/java/com/capstone/interview/controller/InternalQnaController.java
@@ -1,6 +1,7 @@
 package com.capstone.interview.controller;
 
 import com.capstone.interview.dto.InternalQnaRequest;
+import com.capstone.interview.dto.InternalSpeakerRequest;
 import com.capstone.interview.service.InternalQnaService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,18 @@ public class InternalQnaController {
         log.info("[QnA 저장] sessionId={}, turnNumber={}", sessionId, request.turnNumber());
 
         internalQnaService.upsertQna(sessionId, request);
+
+        return ResponseEntity.ok(Map.of("success", true));
+    }
+
+    @PostMapping("/{sessionId}/speaker")
+    public ResponseEntity<Map<String, Boolean>> updateCurrentSpeaker(
+            @PathVariable String sessionId,
+            @RequestBody InternalSpeakerRequest request) {
+        log.info("[Current speaker update] sessionId={}, turnNumber={}, memberId={}, identity={}",
+                sessionId, request.turnNumber(), request.memberId(), request.identity());
+
+        internalQnaService.updateCurrentSpeaker(sessionId, request);
 
         return ResponseEntity.ok(Map.of("success", true));
     }

--- a/src/main/java/com/capstone/interview/controller/InterviewController.java
+++ b/src/main/java/com/capstone/interview/controller/InterviewController.java
@@ -55,6 +55,15 @@ public class InterviewController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/{sessionId}/participants/me/leave")
+    public ResponseEntity<SessionEndResponse> leaveSession(@PathVariable String sessionId) {
+        log.info("[그룹 면접 나가기 요청] sessionId={}", sessionId);
+
+        SessionEndResponse response = interviewService.leaveSession(sessionId);
+        log.info("[그룹 면접 나가기 성공] sessionId={}, status={}", sessionId, response.data().status());
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/{sessionId}/join")
     public ResponseEntity<JoinSessionResponse> joinSession(
             @PathVariable String sessionId,

--- a/src/main/java/com/capstone/interview/dto/InternalSpeakerRequest.java
+++ b/src/main/java/com/capstone/interview/dto/InternalSpeakerRequest.java
@@ -1,0 +1,7 @@
+package com.capstone.interview.dto;
+
+public record InternalSpeakerRequest(
+    Integer turnNumber,
+    Long memberId,
+    String identity
+) {}

--- a/src/main/java/com/capstone/interview/entity/InterviewParticipant.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewParticipant.java
@@ -46,6 +46,9 @@ public class InterviewParticipant {
     @Column(name = "overall_score", length = 20)
     private String overallScore;
 
+    @Column(name = "left_at")
+    private LocalDateTime leftAt;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -70,6 +73,14 @@ public class InterviewParticipant {
     public void saveTotalFeedback(String totalFeedback, String overallScore) {
         this.totalFeedback = totalFeedback;
         this.overallScore = overallScore;
+    }
+
+    public void markLeft() {
+        this.leftAt = LocalDateTime.now();
+    }
+
+    public boolean hasLeft() {
+        return leftAt != null;
     }
 
     public boolean hasFeedback() {

--- a/src/main/java/com/capstone/interview/service/InternalQnaService.java
+++ b/src/main/java/com/capstone/interview/service/InternalQnaService.java
@@ -1,6 +1,7 @@
 package com.capstone.interview.service;
 
 import com.capstone.interview.dto.InternalQnaRequest;
+import com.capstone.interview.dto.InternalSpeakerRequest;
 import com.capstone.interview.entity.Interview;
 import com.capstone.interview.entity.InterviewQna;
 import com.capstone.interview.event.QnaSavedEvent;
@@ -86,6 +87,35 @@ public class InternalQnaService {
 
         if (request.turnNumber() != null && request.answerSummary() != null) {
             eventPublisher.publishEvent(new QnaSavedEvent(sessionId, request.turnNumber()));
+        }
+    }
+
+    @Transactional
+    public void updateCurrentSpeaker(String sessionId, InternalSpeakerRequest request) {
+        Interview interview = interviewRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new SessionNotFoundException("존재하지 않는 세션입니다: " + sessionId));
+
+        Long memberId = request.memberId() != null
+                ? request.memberId()
+                : parseMemberIdFromIdentity(request.identity());
+        if (memberId == null) {
+            log.warn("[Current speaker update] speaker id missing sessionId={}, identity={}",
+                    sessionId, request.identity());
+            return;
+        }
+
+        interview.setCurrentSpeakerMemberId(memberId);
+        interviewRepository.save(interview);
+    }
+
+    private Long parseMemberIdFromIdentity(String identity) {
+        if (identity == null || !identity.startsWith("user-")) {
+            return null;
+        }
+        try {
+            return Long.parseLong(identity.substring("user-".length()));
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -185,7 +185,11 @@ public class InterviewService {
     @Transactional
     public NextTurnResponse nextTurn(String sessionId, NextTurnRequest request) {
         Interview interview = findInterviewOrThrow(sessionId);
-        verifyHost(interview);
+        if (interview.isGroupMode()) {
+            verifyCurrentSpeaker(interview);
+        } else {
+            verifyOwner(interview);
+        }
         verifyInProgress(interview);
 
         int currentTurn = interviewQnaRepository.countByInterview(interview);
@@ -253,6 +257,38 @@ public class InterviewService {
                 true,
                 "면접이 종료되었습니다. AI 피드백을 생성 중입니다.",
                 new SessionEndResponse.Data(interview.getStatus().name())
+        );
+    }
+
+    @Transactional
+    public SessionEndResponse leaveSession(String sessionId) {
+        Interview interview = findInterviewOrThrow(sessionId);
+        if (!interview.isGroupMode()) {
+            throw new InvalidStateException("그룹 면접에서만 개인 나가기를 사용할 수 있습니다.");
+        }
+
+        Member member = currentMember();
+        InterviewParticipant participant = findParticipantOrThrow(interview, member);
+        participant.markLeft();
+        participantRepository.save(participant);
+
+        try {
+            Map<String, Object> message = Map.of(
+                    "type", "PARTICIPANT_LEFT",
+                    "payload", Map.of(
+                            "memberId", member.getId(),
+                            "identity", participant.liveKitIdentity()
+                    )
+            );
+            liveKitRoomService.sendData(interview.getRoomName(), message);
+        } catch (Exception e) {
+            log.warn("[leave] sendData(PARTICIPANT_LEFT) 실패 sessionId={}", sessionId, e);
+        }
+
+        return new SessionEndResponse(
+                true,
+                "그룹 면접에서 나갔습니다.",
+                new SessionEndResponse.Data("LEFT")
         );
     }
 
@@ -493,6 +529,18 @@ public class InterviewService {
         InterviewParticipant participant = findParticipantOrThrow(interview, member);
         if (participant.getRole() != ParticipantRole.HOST) {
             throw new UnauthorizedException("호스트만 이 작업을 수행할 수 있습니다.");
+        }
+    }
+
+    private void verifyCurrentSpeaker(Interview interview) {
+        Member member = currentMember();
+        findParticipantOrThrow(interview, member);
+        Long currentSpeakerMemberId = interview.getCurrentSpeakerMemberId();
+        if (currentSpeakerMemberId == null) {
+            throw new InvalidStateException("현재 답변자 정보가 아직 준비되지 않았습니다.");
+        }
+        if (!currentSpeakerMemberId.equals(member.getId())) {
+            throw new UnauthorizedException("현재 답변자만 다음 질문을 요청할 수 있습니다.");
         }
     }
 

--- a/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
@@ -138,6 +138,80 @@ class GroupInterviewFlowTest {
                 "START".equals(m.get("type")) && !m.containsKey("payload")));
     }
 
+    @Test
+    void nextTurn_allowsCurrentSpeakerGuest() {
+        Interview interview = groupInterviewInProgress();
+        interview.setCurrentSpeakerMemberId(guest.getId());
+        InterviewParticipant guestP = InterviewParticipant.builder()
+                .interview(interview).member(guest).role(ParticipantRole.GUEST).ready(true).build();
+
+        loginAs(guest);
+        when(memberRepository.findByLoginId("guest")).thenReturn(Optional.of(guest));
+        when(interviewRepository.findBySessionId("sess-group-1")).thenReturn(Optional.of(interview));
+        when(participantRepository.findByInterviewAndMember(interview, guest)).thenReturn(Optional.of(guestP));
+        when(interviewQnaRepository.countByInterview(interview)).thenReturn(1);
+        when(interviewQnaRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        NextTurnResponse response = interviewService.nextTurn(
+                "sess-group-1",
+                new NextTurnRequest(1));
+
+        assertEquals(2, response.data().turnNumber());
+        verify(liveKitRoomService).sendData(eq("room-1"), argThat(m -> "NEXT".equals(m.get("type"))));
+    }
+
+    @Test
+    void nextTurn_rejectsNonCurrentSpeaker() {
+        Interview interview = groupInterviewInProgress();
+        interview.setCurrentSpeakerMemberId(host.getId());
+        InterviewParticipant guestP = InterviewParticipant.builder()
+                .interview(interview).member(guest).role(ParticipantRole.GUEST).ready(true).build();
+
+        loginAs(guest);
+        when(memberRepository.findByLoginId("guest")).thenReturn(Optional.of(guest));
+        when(interviewRepository.findBySessionId("sess-group-1")).thenReturn(Optional.of(interview));
+        when(participantRepository.findByInterviewAndMember(interview, guest)).thenReturn(Optional.of(guestP));
+
+        assertThrows(RuntimeException.class, () -> interviewService.nextTurn(
+                "sess-group-1",
+                new NextTurnRequest(1)));
+    }
+
+    @Test
+    void leaveSession_marksParticipantLeftWithoutCompletingInterview() {
+        Interview interview = groupInterviewInProgress();
+        InterviewParticipant guestP = InterviewParticipant.builder()
+                .interview(interview).member(guest).role(ParticipantRole.GUEST).ready(true).build();
+
+        loginAs(guest);
+        when(memberRepository.findByLoginId("guest")).thenReturn(Optional.of(guest));
+        when(interviewRepository.findBySessionId("sess-group-1")).thenReturn(Optional.of(interview));
+        when(participantRepository.findByInterviewAndMember(interview, guest)).thenReturn(Optional.of(guestP));
+
+        SessionEndResponse response = interviewService.leaveSession("sess-group-1");
+
+        assertEquals("LEFT", response.data().status());
+        assertTrue(guestP.hasLeft());
+        assertEquals(InterviewStatus.IN_PROGRESS, interview.getStatus());
+        verify(liveKitRoomService).sendData(eq("room-1"), argThat(m -> "PARTICIPANT_LEFT".equals(m.get("type"))));
+    }
+
+    private Interview groupInterviewInProgress() {
+        Interview interview = Interview.builder()
+                .member(host)
+                .category("BACKEND")
+                .sessionId("sess-group-1")
+                .roomName("room-1")
+                .durationMinutes(15)
+                .maxParticipants(2)
+                .mode(InterviewMode.GROUP)
+                .build();
+        interview.enterWaitingLobby();
+        interview.start();
+        setId(interview, 10L);
+        return interview;
+    }
+
     private void loginAs(Member member) {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(member.getLoginId(), null));


### PR DESCRIPTION
## 해결한 문제
그룹 면접에서 다음 질문 요청이 호스트에게만 허용되어, 게스트가 본인 차례에도 면접을 진행할 수 없던 문제를 해결했습니다. 또한 그룹 면접에서 나가기 동작이 세션 전체 종료와 분리되지 않아 참가자 개인만 빠지는 흐름을 표현할 수 없었습니다.

## 변경 내용
- `/next` 권한을 그룹 면접에서는 호스트가 아니라 현재 답변자 기준으로 검증하도록 변경했습니다.
- RAG agent가 전달하는 현재 화자 정보를 저장하기 위한 internal speaker API를 추가했습니다.
- 그룹 면접 개인 나가기 API(`/participants/me/leave`)를 추가하고, 참가자의 `leftAt` 상태를 저장하도록 했습니다.
- `PARTICIPANT_LEFT` LiveKit data message를 전송해 다른 클라이언트가 참가자 이탈을 알 수 있게 했습니다.
- 운영 DB용 그룹 면접 SQL에 `left_at` 컬럼을 반영했습니다.
- 현재 화자 게스트의 `/next` 성공, 비화자 `/next` 거부, 개인 나가기 동작에 대한 테스트를 추가했습니다.

## 동작 방식
질문이 발행되면 RAG가 현재 답변자 memberId를 백엔드에 동기화합니다. 이후 `/next` 요청이 들어오면 백엔드는 요청자가 현재 답변자인지 확인한 뒤 다음 턴을 생성하고 `NEXT` 이벤트를 방에 브로드캐스트합니다. 그룹 면접에서 나가기를 누르면 인터뷰 세션은 계속 진행되고 해당 참가자만 `leftAt`이 기록됩니다.

## 검증
- `./gradlew test`