### PR TITLE
[Fix] 그룹 면접 개인 종료 피드백 생성

### DIFF
--- a/src/main/java/com/capstone/interview/service/EvaluationService.java
+++ b/src/main/java/com/capstone/interview/service/EvaluationService.java
@@ -192,6 +192,27 @@ public class EvaluationService {
         }
     }
 
+    @Async
+    @Transactional
+    public void evaluateParticipant(String sessionId, Long memberId) {
+        waitForLastAgentSave();
+
+        Interview interview = interviewRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
+        InterviewParticipant participant = participantRepository
+                .findByInterviewOrderByJoinedAtAsc(interview)
+                .stream()
+                .filter(p -> p.getMember().getId().equals(memberId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("면접 참가자를 찾을 수 없습니다: " + sessionId + "#" + memberId));
+
+        if (participant.hasFeedback()) {
+            log.info("[evaluation skipped] participant already evaluated memberId={}", memberId);
+            return;
+        }
+        evaluateParticipant(interview, participant);
+    }
+
     private void evaluateParticipant(Interview interview, InterviewParticipant participant) {
         Long memberId = participant.getMember().getId();
         List<InterviewQna> qnas = interviewQnaRepository

--- a/src/main/java/com/capstone/interview/service/FeedbackService.java
+++ b/src/main/java/com/capstone/interview/service/FeedbackService.java
@@ -49,7 +49,7 @@ public class FeedbackService {
             if (rawFeedback == null) {
                 return FeedbackResponse.builder()
                         .success(false)
-                        .totalFeedback(interview.getStatus() == InterviewStatus.COMPLETED
+                        .totalFeedback(interview.getStatus() == InterviewStatus.COMPLETED || participant.hasLeft()
                                 ? "AI 피드백을 생성 중입니다. 잠시 후 다시 시도해주세요."
                                 : "면접이 아직 종료되지 않았습니다.")
                         .qaPairs(List.of())
@@ -104,13 +104,13 @@ public class FeedbackService {
             }
         }
 
-        List<InterviewParticipant> guestRecords =
+        List<InterviewParticipant> participantRecords =
                 participantRepository.findByMemberIdOrderByJoinedAtDesc(member.getId());
-        for (InterviewParticipant p : guestRecords) {
-            Interview interview = p.getInterview();
-            if (interview.getStatus() != InterviewStatus.COMPLETED) {
+        for (InterviewParticipant p : participantRecords) {
+            if (!p.hasFeedback()) {
                 continue;
             }
+            Interview interview = p.getInterview();
             if (interview.getMember() != null && interview.getMember().getId().equals(member.getId())) {
                 continue;
             }

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -284,10 +284,12 @@ public class InterviewService {
             log.warn("[leave] sendData(PARTICIPANT_LEFT) 실패 sessionId={}", sessionId, e);
         }
 
+        evaluationService.evaluateParticipant(sessionId, member.getId());
+
         return new SessionEndResponse(
                 true,
-                "그룹 면접에서 나갔습니다.",
-                new SessionEndResponse.Data("LEFT")
+                "그룹 면접에서 나갔습니다. 개인 피드백을 생성 중입니다.",
+                new SessionEndResponse.Data("EVALUATING")
         );
     }
 

--- a/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
@@ -191,10 +191,11 @@ class GroupInterviewFlowTest {
 
         SessionEndResponse response = interviewService.leaveSession("sess-group-1");
 
-        assertEquals("LEFT", response.data().status());
+        assertEquals("EVALUATING", response.data().status());
         assertTrue(guestP.hasLeft());
         assertEquals(InterviewStatus.IN_PROGRESS, interview.getStatus());
         verify(liveKitRoomService).sendData(eq("room-1"), argThat(m -> "PARTICIPANT_LEFT".equals(m.get("type"))));
+        verify(evaluationService).evaluateParticipant("sess-group-1", guest.getId());
     }
 
     private Interview groupInterviewInProgress() {


### PR DESCRIPTION
## 해결한 문제
- 그룹 면접 참가자가 중간에 나가면 호스트가 전체 면접을 종료하기 전까지 개인 피드백과 기록을 볼 수 없던 문제를 수정했습니다.
- 그룹 세션은 계속 진행 중이어도 나간 참가자의 개인 평가를 생성할 수 있도록 했습니다.

## 변경 내용
- 그룹 면접 개인 나가기 시 참가자 leftAt을 기록한 뒤 해당 참가자 평가를 비동기로 시작합니다.
- leave 응답 상태를 EVALUATING으로 반환해 프론트가 결과 대기 화면으로 이동할 수 있게 했습니다.
- 그룹 세션이 COMPLETED가 아니어도, 내 참가자 피드백이 생성된 경우 피드백 조회와 기록 목록 노출이 가능하도록 했습니다.
- 관련 서비스 테스트 기대값을 개인 평가 생성 흐름에 맞게 갱신했습니다.

## 확인
- ./gradlew test