### PR TITLE
[Fix] Agent 세션 실패 수신 및 FAILED 상태 처리

### DIFF
--- a/src/main/java/com/capstone/interview/controller/InternalQnaController.java
+++ b/src/main/java/com/capstone/interview/controller/InternalQnaController.java
@@ -1,6 +1,7 @@
 package com.capstone.interview.controller;
 
 import com.capstone.interview.dto.InternalQnaRequest;
+import com.capstone.interview.dto.InternalSessionFailureRequest;
 import com.capstone.interview.dto.InternalSpeakerRequest;
 import com.capstone.interview.service.InternalQnaService;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,17 @@ public class InternalQnaController {
                 sessionId, request.turnNumber(), request.memberId(), request.identity());
 
         internalQnaService.updateCurrentSpeaker(sessionId, request);
+
+        return ResponseEntity.ok(Map.of("success", true));
+    }
+
+    @PostMapping("/{sessionId}/failed")
+    public ResponseEntity<Map<String, Boolean>> markSessionFailed(
+            @PathVariable String sessionId,
+            @RequestBody InternalSessionFailureRequest request) {
+        log.warn("[Session failed] sessionId={}, reason={}", sessionId, request.reason());
+
+        internalQnaService.markSessionFailed(sessionId, request);
 
         return ResponseEntity.ok(Map.of("success", true));
     }

--- a/src/main/java/com/capstone/interview/dto/FeedbackResponse.java
+++ b/src/main/java/com/capstone/interview/dto/FeedbackResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 @Builder
 public class FeedbackResponse {
     private boolean success;
+    private String status;
     private String totalFeedback; // AI의 전체 총평
     private String overallScore;
     private String competencyChart; //차트

--- a/src/main/java/com/capstone/interview/dto/InternalSessionFailureRequest.java
+++ b/src/main/java/com/capstone/interview/dto/InternalSessionFailureRequest.java
@@ -1,0 +1,6 @@
+package com.capstone.interview.dto;
+
+public record InternalSessionFailureRequest(
+        String reason
+) {
+}

--- a/src/main/java/com/capstone/interview/service/EvaluationService.java
+++ b/src/main/java/com/capstone/interview/service/EvaluationService.java
@@ -5,6 +5,7 @@ import com.capstone.interview.entity.Interview;
 import com.capstone.interview.entity.InterviewMode;
 import com.capstone.interview.entity.InterviewParticipant;
 import com.capstone.interview.entity.InterviewQna;
+import com.capstone.interview.entity.InterviewStatus;
 import com.capstone.interview.event.QnaSavedEvent;
 import com.capstone.interview.repository.InterviewParticipantRepository;
 import com.capstone.interview.repository.InterviewQnaRepository;
@@ -137,6 +138,11 @@ public class EvaluationService {
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
 
+        if (interview.getStatus() == InterviewStatus.FAILED) {
+            log.warn("[evaluation skipped] failed sessionId={}", sessionId);
+            return;
+        }
+
         if (interview.getMode() == InterviewMode.GROUP) {
             evaluateAllParticipants(sessionId);
             return;
@@ -179,6 +185,11 @@ public class EvaluationService {
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
 
+        if (interview.getStatus() == InterviewStatus.FAILED) {
+            log.warn("[participant evaluation skipped] failed sessionId={}", sessionId);
+            return;
+        }
+
         List<InterviewParticipant> participants =
                 participantRepository.findByInterviewOrderByJoinedAtAsc(interview);
 
@@ -199,6 +210,11 @@ public class EvaluationService {
 
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
+        if (interview.getStatus() == InterviewStatus.FAILED) {
+            log.warn("[participant evaluation skipped] failed sessionId={}, memberId={}", sessionId, memberId);
+            return;
+        }
+
         InterviewParticipant participant = participantRepository
                 .findByInterviewOrderByJoinedAtAsc(interview)
                 .stream()

--- a/src/main/java/com/capstone/interview/service/FeedbackService.java
+++ b/src/main/java/com/capstone/interview/service/FeedbackService.java
@@ -46,9 +46,16 @@ public class FeedbackService {
             List<InterviewQna> qnas = interviewQnaRepository
                     .findByInterviewAndRespondentMemberIdOrderBySequenceNumberAsc(interview, member.getId());
 
+            if (interview.getStatus() == InterviewStatus.FAILED) {
+                return failedFeedbackResponse();
+            }
+
             if (rawFeedback == null) {
                 return FeedbackResponse.builder()
                         .success(false)
+                        .status(interview.getStatus() == InterviewStatus.COMPLETED || participant.hasLeft()
+                                ? "EVALUATING"
+                                : interview.getStatus().name())
                         .totalFeedback(interview.getStatus() == InterviewStatus.COMPLETED || participant.hasLeft()
                                 ? "AI 피드백을 생성 중입니다. 잠시 후 다시 시도해주세요."
                                 : "면접이 아직 종료되지 않았습니다.")
@@ -59,6 +66,7 @@ public class FeedbackService {
             if (qnas.isEmpty()) {
                 return FeedbackResponse.builder()
                         .success(true)
+                        .status("COMPLETED")
                         .totalFeedback(rawFeedback)
                         .overallScore(extractOverallScore(rawFeedback))
                         .competencyChart(extractChartData(rawFeedback))
@@ -73,9 +81,16 @@ public class FeedbackService {
         List<InterviewQna> qnas = interviewQnaRepository
                 .findByInterviewOrderBySequenceNumberAsc(interview);
 
+        if (interview.getStatus() == InterviewStatus.FAILED) {
+            return failedFeedbackResponse();
+        }
+
         if (rawFeedback == null) {
             return FeedbackResponse.builder()
                     .success(false)
+                    .status(interview.getStatus() == InterviewStatus.COMPLETED
+                            ? "EVALUATING"
+                            : interview.getStatus().name())
                     .totalFeedback(interview.getStatus() == InterviewStatus.COMPLETED
                             ? "AI 피드백을 생성 중입니다. 잠시 후 다시 시도해주세요."
                             : "면접이 아직 종료되지 않았습니다.")
@@ -84,6 +99,15 @@ public class FeedbackService {
         }
 
         return buildFeedbackResponse(rawFeedback, qnas);
+    }
+
+    private FeedbackResponse failedFeedbackResponse() {
+        return FeedbackResponse.builder()
+                .success(false)
+                .status("FAILED")
+                .totalFeedback("AI 면접관 연결 문제로 면접이 중단되었습니다. 새 면접을 시작해주세요.")
+                .qaPairs(List.of())
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -153,6 +177,7 @@ public class FeedbackService {
 
         return FeedbackResponse.builder()
                 .success(true)
+                .status("COMPLETED")
                 .totalFeedback(onlyFeedback)
                 .overallScore(extractOverallScore(rawFeedback))
                 .competencyChart(onlyChart)

--- a/src/main/java/com/capstone/interview/service/InternalQnaService.java
+++ b/src/main/java/com/capstone/interview/service/InternalQnaService.java
@@ -1,8 +1,10 @@
 package com.capstone.interview.service;
 
 import com.capstone.interview.dto.InternalQnaRequest;
+import com.capstone.interview.dto.InternalSessionFailureRequest;
 import com.capstone.interview.dto.InternalSpeakerRequest;
 import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.InterviewStatus;
 import com.capstone.interview.entity.InterviewQna;
 import com.capstone.interview.event.QnaSavedEvent;
 import com.capstone.interview.exception.SessionNotFoundException;
@@ -112,6 +114,21 @@ public class InternalQnaService {
 
         interview.setCurrentSpeakerMemberId(memberId);
         interviewRepository.save(interview);
+    }
+
+    @Transactional
+    public void markSessionFailed(String sessionId, InternalSessionFailureRequest request) {
+        Interview interview = interviewRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new SessionNotFoundException("session not found: " + sessionId));
+
+        if (interview.getStatus() == InterviewStatus.COMPLETED || interview.getStatus() == InterviewStatus.FAILED) {
+            log.info("[Session failed ignored] sessionId={}, status={}", sessionId, interview.getStatus());
+            return;
+        }
+
+        interview.fail();
+        interviewRepository.save(interview);
+        log.warn("[Session marked failed] sessionId={}, reason={}", sessionId, request.reason());
     }
 
     private Long parseMemberIdFromIdentity(String identity) {


### PR DESCRIPTION
## 해결한 문제

- Agent가 세션 실패를 알려도 Backend가 받아줄 엔드포인트가 없어 면접이 FAILED 처리되지 않던 문제를 수정했습니다.
- FAILED 상태 세션에 대해 평가와 피드백 조회가 그대로 진행되던 문제를 수정했습니다.
- 피드백 응답에 `status` 필드가 없어 프론트가 EVALUATING/FAILED를 구분할 수 없던 문제를 수정했습니다.

## 변경 내용

- `InternalSessionFailureRequest` DTO 추가 (`reason` 필드)
- `POST /internal/v1/interviews/sessions/{sessionId}/failed` 엔드포인트 추가
- `InternalQnaService.markSessionFailed()`: COMPLETED/FAILED 상태면 무시, 그 외 `interview.fail()` 호출
- `EvaluationService`: `evaluateSingleInterview()` / `evaluateAllParticipants()` / `evaluateSingleParticipant()` 에서 FAILED 상태 시 평가 skip
- `FeedbackResponse`: `status` 필드 추가
- `FeedbackService`: FAILED 상태 시 `failedFeedbackResponse()` 반환, 평가 중/완료 구분하여 `status` 반환

## 커밋 구성

- `fix: Agent 세션 실패 알림 엔드포인트 추가`
- `fix: FAILED 상태 면접 세션 평가 skip 처리`
- `fix: FeedbackResponse에 status 필드 추가 및 FAILED 상태 응답 처리`

## 확인

- `./gradlew test`
