### PR TITLE
[Feature] 이력서 전처리 저장

### DIFF
--- a/src/main/java/com/capstone/interview/config/MockLLMClient.java
+++ b/src/main/java/com/capstone/interview/config/MockLLMClient.java
@@ -37,6 +37,24 @@ public class MockLLMClient implements LLMClient {
                     """;
         }
 
+        if (merged.contains("claims") && merged.contains("이력서")) {
+            return """
+                    {
+                      "summary": "AI 모의면접 프로젝트에서 백엔드와 RAG 기반 질문 생성 구조를 구현한 지원자",
+                      "claims": [
+                        {
+                          "text": "AI 모의면접 시스템에서 이력서 텍스트 기반 맞춤형 기술 면접 질문 생성을 구현했다",
+                          "keywords": ["AI 모의면접", "질문 생성", "이력서 기반"]
+                        },
+                        {
+                          "text": "pgvector 기반 RAG 파이프라인을 구축하고 실제 면접 후기 크롤링 데이터로 질문 현실성을 높였다",
+                          "keywords": ["pgvector", "RAG", "크롤링", "유사도 검색"]
+                        }
+                      ]
+                    }
+                    """;
+        }
+
         return """
                 {
                   "individual_feedback": "핵심 개념은 잘 짚었지만, 동작 원리와 실제 적용 경험을 함께 설명하면 더 설득력 있는 답변이 됩니다.",

--- a/src/main/java/com/capstone/interview/service/PdfParserService.java
+++ b/src/main/java/com/capstone/interview/service/PdfParserService.java
@@ -30,11 +30,48 @@ public class PdfParserService {
         try (PDDocument document = Loader.loadPDF(bytes)) {
 
             PDFTextStripper stripper = new PDFTextStripper();
-            String text = stripper.getText(document);
+            stripper.setSortByPosition(true);
 
-            String cleanedText = text.replace("\u0000", "");
+            String text = stripper.getText(document);
+            String cleanedText = cleanExtractedText(text);
             log.info("[PDF 파싱] 완료: {}페이지, {}글자", document.getNumberOfPages(), cleanedText.length());
-            return cleanedText.trim();
+            return cleanedText;
         }
+    }
+
+    private String cleanExtractedText(String text) {
+        if (text == null) {
+            return "";
+        }
+
+        String normalized = text
+                .replace("\u0000", "")
+                .replace("\r\n", "\n")
+                .replace("\r", "\n");
+
+        String[] lines = normalized.split("\n");
+        StringBuilder builder = new StringBuilder();
+        boolean previousBlank = false;
+
+        for (String line : lines) {
+            String cleanedLine = line.replaceAll("[\\t\\f\\x0B]+", " ")
+                    .replaceAll(" {2,}", " ")
+                    .trim();
+            if (cleanedLine.isBlank()) {
+                if (!previousBlank && !builder.isEmpty()) {
+                    builder.append('\n');
+                }
+                previousBlank = true;
+                continue;
+            }
+
+            if (!builder.isEmpty() && !previousBlank) {
+                builder.append('\n');
+            }
+            builder.append(cleanedLine);
+            previousBlank = false;
+        }
+
+        return builder.toString().trim();
     }
 }

--- a/src/main/java/com/capstone/interview/service/ResumePreprocessorService.java
+++ b/src/main/java/com/capstone/interview/service/ResumePreprocessorService.java
@@ -1,0 +1,97 @@
+package com.capstone.interview.service;
+
+import com.capstone.interview.config.LLMClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ResumePreprocessorService {
+
+    private static final int MAX_RESUME_CHARS = 8_000;
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 이력서 원문을 면접 질문 생성에 쓰기 좋은 구조화 JSON으로 정리하는 도우미입니다.
+
+            규칙:
+            - 질문을 만들지 마세요.
+            - 이력서에 실제로 적힌 내용만 정리하세요.
+            - 없는 경험, 성과, 기술을 추측하거나 추가하지 마세요.
+            - 프로젝트/경험 중심으로 정리하되, 각 claim에는 관련 기술스택 keywords를 반드시 포함하세요.
+            - 응답은 JSON 객체 하나만 출력하세요.
+            """;
+
+    private static final String USER_PROMPT_TEMPLATE = """
+            아래 이력서 원문을 다음 JSON 스키마로 정리하세요.
+
+            {
+              "summary": "이력서 내용 요약 1문장",
+              "claims": [
+                {
+                  "text": "지원자가 이력서에 쓴 프로젝트/경험/역할/구현 사실 1개",
+                  "keywords": ["해당 claim과 직접 연결된 기술스택 또는 검색 키워드"]
+                }
+              ]
+            }
+
+            세부 기준:
+            - claims는 최대 8개까지 작성하세요.
+            - claims.text는 "RAG를 사용했다"처럼 너무 일반적으로 쓰지 말고, 프로젝트 맥락을 포함하세요.
+            - claims.keywords에는 Java, Spring Boot, JPA, PostgreSQL, AWS Bedrock, pgvector, RAG처럼 실제 기술명을 우선 포함하세요.
+            - 기술스택이 명시되지 않은 claim은 keywords에 프로젝트 도메인 키워드를 넣으세요.
+
+            [이력서 원문]
+            %s
+            """;
+
+    private final LLMClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public String preprocess(String originalText) {
+        if (originalText == null || originalText.isBlank()) {
+            throw new IllegalArgumentException("이력서 원문이 비어있습니다.");
+        }
+
+        String resumeText = limitLength(originalText);
+        String response = llmClient.invoke(SYSTEM_PROMPT, USER_PROMPT_TEMPLATE.formatted(resumeText));
+        try {
+            JsonNode root = objectMapper.readTree(response.trim());
+            validate(root);
+            return objectMapper.writeValueAsString(root);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("이력서 전처리 응답 파싱에 실패했습니다.", e);
+        }
+    }
+
+    private String limitLength(String text) {
+        String trimmed = text.trim();
+        if (trimmed.length() <= MAX_RESUME_CHARS) {
+            return trimmed;
+        }
+        return trimmed.substring(0, MAX_RESUME_CHARS);
+    }
+
+    private void validate(JsonNode root) {
+        if (!root.isObject()) {
+            throw new IllegalArgumentException("전처리 결과가 JSON 객체가 아닙니다.");
+        }
+        if (!root.hasNonNull("summary") || root.path("summary").asText().isBlank()) {
+            throw new IllegalArgumentException("전처리 결과에 summary가 없습니다.");
+        }
+        JsonNode claims = root.path("claims");
+        if (!claims.isArray() || claims.isEmpty()) {
+            throw new IllegalArgumentException("전처리 결과에 claims가 없습니다.");
+        }
+        for (JsonNode claim : claims) {
+            if (claim.path("text").asText().isBlank()) {
+                throw new IllegalArgumentException("claim.text가 비어있습니다.");
+            }
+            JsonNode keywords = claim.path("keywords");
+            if (!keywords.isArray() || keywords.isEmpty()) {
+                throw new IllegalArgumentException("claim.keywords가 비어있습니다.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/capstone/interview/service/ResumeService.java
+++ b/src/main/java/com/capstone/interview/service/ResumeService.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class ResumeService {
 
     private final PdfParserService pdfParserService;
+    private final ResumePreprocessorService resumePreprocessorService;
     private final ResumeRepository resumeRepository;
     private final MemberRepository memberRepository;
     private final InterviewRepository interviewRepository;
@@ -48,10 +49,12 @@ public class ResumeService {
         }
 
         // DB 저장
+        String keywords = preprocessSafely(originalText);
         Resume resume = Resume.builder()
                 .member(member)
                 .title(title)
                 .originalText(originalText)
+                .keywords(keywords)
                 .build();
 
         Resume saved = resumeRepository.save(resume);
@@ -73,10 +76,12 @@ public class ResumeService {
             throw new IllegalArgumentException("이력서 텍스트가 비어있습니다.");
         }
 
+        String keywords = preprocessSafely(request.originalText());
         Resume resume = Resume.builder()
                 .member(member)
                 .title(request.title())
                 .originalText(request.originalText())
+                .keywords(keywords)
                 .build();
 
         Resume saved = resumeRepository.save(resume);
@@ -141,5 +146,14 @@ public class ResumeService {
                 resume.getKeywords(),
                 resume.getCreatedAt()
         );
+    }
+
+    private String preprocessSafely(String originalText) {
+        try {
+            return resumePreprocessorService.preprocess(originalText);
+        } catch (Exception e) {
+            log.warn("[이력서 전처리 실패] 원문 저장은 계속 진행합니다. reason={}", e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/test/java/com/capstone/interview/service/ResumePreprocessorServiceTest.java
+++ b/src/test/java/com/capstone/interview/service/ResumePreprocessorServiceTest.java
@@ -1,0 +1,36 @@
+package com.capstone.interview.service;
+
+import com.capstone.interview.config.MockLLMClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResumePreprocessorServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ResumePreprocessorService service = new ResumePreprocessorService(
+            new MockLLMClient(),
+            objectMapper
+    );
+
+    @Test
+    void preprocess_returns_summary_and_claims_with_keywords() throws Exception {
+        String result = service.preprocess("""
+                AI 모의면접 시스템
+                Spring Boot 백엔드와 pgvector 기반 RAG 파이프라인을 구축했습니다.
+                실제 면접 후기 크롤링 데이터로 질문 현실성을 높였습니다.
+                """);
+
+        JsonNode root = objectMapper.readTree(result);
+
+        assertFalse(root.path("summary").asText().isBlank());
+        assertTrue(root.path("claims").isArray());
+        assertFalse(root.path("claims").isEmpty());
+        assertFalse(root.path("claims").get(0).path("text").asText().isBlank());
+        assertTrue(root.path("claims").get(0).path("keywords").isArray());
+        assertFalse(root.path("claims").get(0).path("keywords").isEmpty());
+    }
+}


### PR DESCRIPTION
﻿## 해결한 문제

- 이력서 PDF 원문이 그대로 저장되고 이후 질문 생성에 쓰일 수 있어, 프로젝트 경험과 기술스택을 안정적으로 참조하기 어려운 문제가 있었습니다.
- PDFBox 추출 결과의 줄바꿈/공백 노이즈가 남아 LLM 전처리 입력 품질이 흔들릴 수 있었습니다.

## 변경 내용

- `PdfParserService`에서 PDF 텍스트 추출 시 위치 기반 정렬과 공백/개행 후처리를 적용했습니다.
- `ResumePreprocessorService`를 추가해 이력서 원문을 `summary`와 `claims` JSON으로 정리합니다.
- 각 claim은 프로젝트/경험 사실과 직접 연결된 기술스택 `keywords`를 포함하도록 프롬프트를 구성했습니다.
- PDF 업로드와 텍스트 업로드 모두 저장 시 전처리를 수행하고, 결과를 기존 `Resume.keywords` 컬럼에 저장합니다.
- 전처리 실패 시 이력서 원문 저장은 계속 진행되도록 fallback 처리했습니다.
- mock LLM과 전처리 서비스 테스트를 추가했습니다.

## 어떻게 동작하는지

- 사용자가 이력서를 업로드하면 기존처럼 PDF에서 텍스트를 추출해 `originalText`에 저장합니다.
- 저장 전 Sonnet/Mock LLM이 원문을 읽고 `summary`, `claims`, `keywords` 구조로 정리합니다.
- 정리된 JSON은 `keywords`에 저장되어 이후 Agent가 이력서 전체 원문 대신 지원자의 실제 경험과 관련 기술스택을 참조할 수 있는 기반이 됩니다.

## 커밋 구성

- `feat: 이력서 전처리 저장`

## 확인

- `./gradlew test`
