### PR TITLE
[Feature] 이력서 프로필 전달

### DIFF
--- a/src/main/java/com/capstone/interview/service/AgentDispatchService.java
+++ b/src/main/java/com/capstone/interview/service/AgentDispatchService.java
@@ -48,12 +48,14 @@ public class AgentDispatchService {
      */
     public void dispatch(String roomName, String sessionId, String jobRole,
                          String resumeText, String coverLetterText,
+                         String resumeProfile,
                          int totalDurationSeconds, int answerTimeLimitSeconds) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put("mode", "SOLO");
         metadata.put("sessionId", sessionId);
         metadata.put("jobRole", jobRole);
         metadata.put("resumeText", resumeText != null ? resumeText : "");
+        metadata.put("resumeProfile", resumeProfile != null ? resumeProfile : "");
         metadata.put("coverLetterText", coverLetterText != null ? coverLetterText : "");
         metadata.put("totalDurationSeconds", totalDurationSeconds);
         metadata.put("answerTimeLimitSeconds", answerTimeLimitSeconds);
@@ -62,6 +64,7 @@ public class AgentDispatchService {
 
     public void dispatchGroup(String roomName, String sessionId, String jobRole,
                               String resumeText, String coverLetterText,
+                              String resumeProfile,
                               int totalDurationSeconds, int answerTimeLimitSeconds,
                               int maxParticipants, List<Map<String, Object>> participants) {
         Map<String, Object> metadata = new LinkedHashMap<>();
@@ -69,6 +72,7 @@ public class AgentDispatchService {
         metadata.put("sessionId", sessionId);
         metadata.put("jobRole", jobRole);
         metadata.put("resumeText", resumeText != null ? resumeText : "");
+        metadata.put("resumeProfile", resumeProfile != null ? resumeProfile : "");
         metadata.put("coverLetterText", coverLetterText != null ? coverLetterText : "");
         metadata.put("totalDurationSeconds", totalDurationSeconds);
         metadata.put("answerTimeLimitSeconds", answerTimeLimitSeconds);

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -320,6 +320,7 @@ public class InterviewService {
                     interview.getCategory(),
                     "",
                     "",
+                    "",
                     interview.getDurationMinutes() * 60,
                     ANSWER_TIME_LIMIT_SECONDS,
                     interview.getMaxParticipants(),
@@ -340,18 +341,20 @@ public class InterviewService {
                                           String jobField, int totalDurationSeconds,
                                           List<Map<String, Object>> participantMeta) {
         String resumeText = resume != null ? resume.getOriginalText() : "";
+        String resumeProfile = resume != null ? resume.getKeywords() : "";
         String coverLetterText = coverLetter != null ? coverLetter.getOriginalText() : "";
 
         try {
             if (interview.isGroupMode()) {
                 agentDispatchService.dispatchGroup(
                         interview.getRoomName(), interview.getSessionId(), jobField,
-                        "", "", totalDurationSeconds,
+                        "", "", "", totalDurationSeconds,
                         ANSWER_TIME_LIMIT_SECONDS, interview.getMaxParticipants(), participantMeta);
             } else {
                 agentDispatchService.dispatch(
                         interview.getRoomName(), interview.getSessionId(), jobField,
-                        resumeText, coverLetterText, totalDurationSeconds, ANSWER_TIME_LIMIT_SECONDS);
+                        resumeText, coverLetterText, resumeProfile,
+                        totalDurationSeconds, ANSWER_TIME_LIMIT_SECONDS);
             }
         } catch (Exception e) {
             log.error("[세션 생성] Agent dispatch 실패 sessionId={}", interview.getSessionId(), e);
@@ -390,15 +393,18 @@ public class InterviewService {
         List<Map<String, Object>> meta = new ArrayList<>();
         for (InterviewParticipant p : participants) {
             String resumeText = p.getResume() != null ? p.getResume().getOriginalText() : "";
+            String resumeProfile = p.getResume() != null ? p.getResume().getKeywords() : "";
             if (resumeText.isBlank() && p.getRole() == ParticipantRole.HOST
                     && p.getInterview().getResume() != null) {
                 resumeText = p.getInterview().getResume().getOriginalText();
+                resumeProfile = p.getInterview().getResume().getKeywords();
             }
             meta.add(Map.of(
                     "memberId", p.getMember().getId(),
                     "identity", p.liveKitIdentity(),
                     "name", p.getMember().getName(),
-                    "resumeText", resumeText != null ? resumeText : ""
+                    "resumeText", resumeText != null ? resumeText : "",
+                    "resumeProfile", resumeProfile != null ? resumeProfile : ""
             ));
         }
         return meta;
@@ -422,7 +428,8 @@ public class InterviewService {
                 "memberId", host.getId(),
                 "identity", participant.liveKitIdentity(),
                 "name", host.getName(),
-                "resumeText", resume != null && resume.getOriginalText() != null ? resume.getOriginalText() : ""
+                "resumeText", resume != null && resume.getOriginalText() != null ? resume.getOriginalText() : "",
+                "resumeProfile", resume != null && resume.getKeywords() != null ? resume.getKeywords() : ""
         );
     }
 

--- a/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
+++ b/src/test/java/com/capstone/interview/service/GroupInterviewFlowTest.java
@@ -69,7 +69,7 @@ class GroupInterviewFlowTest {
         assertEquals("WAITING", response.data().status());
         assertEquals("GROUP", response.data().mode());
         assertEquals(2, response.data().maxParticipants());
-        verify(agentDispatchService, never()).dispatchGroup(any(), any(), any(), any(), any(), anyInt(), anyInt(), anyInt(), anyList());
+        verify(agentDispatchService, never()).dispatchGroup(any(), any(), any(), any(), any(), any(), anyInt(), anyInt(), anyInt(), anyList());
     }
 
     @Test
@@ -98,7 +98,7 @@ class GroupInterviewFlowTest {
         var order = inOrder(participantRepository, agentDispatchService);
         order.verify(participantRepository).save(any(InterviewParticipant.class));
         order.verify(agentDispatchService).dispatch(
-                eq("room-test"), anyString(), eq("BACKEND"), anyString(), anyString(), eq(900), anyInt());
+                eq("room-test"), anyString(), eq("BACKEND"), anyString(), anyString(), anyString(), eq(900), anyInt());
     }
 
     @Test
@@ -134,7 +134,7 @@ class GroupInterviewFlowTest {
         LobbyResponse lobby = interviewService.setReady("sess-group-1");
 
         assertEquals("IN_PROGRESS", lobby.data().status());
-        verify(agentDispatchService).dispatchGroup(any(), eq("sess-group-1"), any(), any(), any(), anyInt(), anyInt(), eq(2), anyList());
+        verify(agentDispatchService).dispatchGroup(any(), eq("sess-group-1"), any(), any(), any(), any(), anyInt(), anyInt(), eq(2), anyList());
         verify(liveKitRoomService).sendData(eq("room-1"), argThat(m ->
                 "START".equals(m.get("type")) && !m.containsKey("payload")));
     }


### PR DESCRIPTION
﻿## 해결한 문제

- 이력서 전처리 결과가 `Resume.keywords`에 저장되지만, Agent dispatch metadata에는 원문 `resumeText`만 전달되어 질문 생성 단계에서 전처리 JSON을 활용할 수 없었습니다.
- 그룹 면접 참가자별 이력서 정보에도 전처리 프로필이 포함되지 않아, 참가자별 claim 기반 질문 생성으로 이어질 수 없었습니다.

## 변경 내용

- Agent dispatch metadata에 `resumeProfile` 필드를 추가했습니다.
- 솔로 면접 dispatch 시 `resume.getKeywords()` 값을 `resumeProfile`로 전달합니다.
- 그룹 면접 참가자 metadata에도 참가자별 `resumeProfile`을 포함합니다.
- 기존 `resumeText` 전달은 유지해 전처리 JSON이 없거나 Agent가 구버전이어도 fallback 가능하게 했습니다.
- dispatch 시그니처 변경에 맞춰 그룹 면접 서비스 테스트를 갱신했습니다.

## 어떻게 동작하는지

- 사용자가 이력서를 업로드하면 전처리된 `summary + claims + keywords` JSON이 `Resume.keywords`에 저장됩니다.
- 면접 세션을 시작하면 Backend가 기존 `resumeText`와 함께 `resumeProfile`을 Agent metadata로 전달합니다.
- 이후 Agent는 `resumeProfile.claims`를 읽어 지원자의 실제 경험과 기술스택 기반 질문 생성에 사용할 수 있습니다.

## 커밋 구성

- `feat: 이력서 프로필 전달`

## 확인

- `./gradlew test`
