### PR TITLE
fix: allow next question in group interview when speaker not yet set

### DIFF
--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -542,7 +542,8 @@ public class InterviewService {
         findParticipantOrThrow(interview, member);
         Long currentSpeakerMemberId = interview.getCurrentSpeakerMemberId();
         if (currentSpeakerMemberId == null) {
-            throw new InvalidStateException("현재 답변자 정보가 아직 준비되지 않았습니다.");
+            // Agent가 아직 speaker를 설정하지 않은 경우 참가자이면 허용
+            return;
         }
         if (!currentSpeakerMemberId.equals(member.getId())) {
             throw new UnauthorizedException("현재 답변자만 다음 질문을 요청할 수 있습니다.");


### PR DESCRIPTION
그룹 면접에서 Agent가 currentSpeaker를 아직 설정하지 않은 경우, 참가자이면 다음 질문 요청을 허용하도록 수정