### PR TITLE
[Fix] 이력서 전처리 응답 파싱 수정

### DIFF
--- a/src/main/java/com/capstone/interview/service/ResumePreprocessorService.java
+++ b/src/main/java/com/capstone/interview/service/ResumePreprocessorService.java
@@ -57,7 +57,7 @@ public class ResumePreprocessorService {
         String resumeText = limitLength(originalText);
         String response = llmClient.invoke(SYSTEM_PROMPT, USER_PROMPT_TEMPLATE.formatted(resumeText));
         try {
-            JsonNode root = objectMapper.readTree(response.trim());
+            JsonNode root = objectMapper.readTree(extractJson(response));
             validate(root);
             return objectMapper.writeValueAsString(root);
         } catch (Exception e) {
@@ -71,6 +71,21 @@ public class ResumePreprocessorService {
             return trimmed;
         }
         return trimmed.substring(0, MAX_RESUME_CHARS);
+    }
+
+    private String extractJson(String llmResponse) {
+        if (llmResponse == null) {
+            return "";
+        }
+        String response = llmResponse.trim();
+        if (response.startsWith("```")) {
+            response = response
+                    .replaceAll("^```json\\s*", "")
+                    .replaceAll("^```\\s*", "")
+                    .replaceAll("\\s*```$", "")
+                    .trim();
+        }
+        return response;
     }
 
     private void validate(JsonNode root) {

--- a/src/test/java/com/capstone/interview/service/ResumePreprocessorServiceTest.java
+++ b/src/test/java/com/capstone/interview/service/ResumePreprocessorServiceTest.java
@@ -1,9 +1,12 @@
 package com.capstone.interview.service;
 
+import com.capstone.interview.config.LLMClient;
 import com.capstone.interview.config.MockLLMClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,6 +34,47 @@ class ResumePreprocessorServiceTest {
         assertFalse(root.path("claims").isEmpty());
         assertFalse(root.path("claims").get(0).path("text").asText().isBlank());
         assertTrue(root.path("claims").get(0).path("keywords").isArray());
+        assertFalse(root.path("claims").get(0).path("keywords").isEmpty());
+    }
+
+    @Test
+    void preprocess_accepts_markdown_json_code_block_response() throws Exception {
+        ResumePreprocessorService codeBlockService = new ResumePreprocessorService(
+                new LLMClient() {
+                    @Override
+                    public String invoke(String prompt) {
+                        return invoke("", prompt);
+                    }
+
+                    @Override
+                    public String invoke(String systemPrompt, String userPrompt) {
+                        return """
+                                ```json
+                                {
+                                  "summary": "백엔드 개발 경험",
+                                  "claims": [
+                                    {
+                                      "text": "Java와 Spring Boot 기반 서비스를 구현했다.",
+                                      "keywords": ["Java", "Spring Boot"]
+                                    }
+                                  ]
+                                }
+                                ```
+                                """;
+                    }
+
+                    @Override
+                    public List<Float> embed(String text) {
+                        return List.of();
+                    }
+                },
+                objectMapper
+        );
+
+        String result = codeBlockService.preprocess("Java와 Spring Boot 기반 서비스를 구현했습니다.");
+        JsonNode root = objectMapper.readTree(result);
+
+        assertFalse(root.path("summary").asText().isBlank());
         assertFalse(root.path("claims").get(0).path("keywords").isEmpty());
     }
 }


### PR DESCRIPTION
﻿## 해결한 문제

Haiku 4.5가 이력서 전처리 응답을 순수 JSON이 아니라 Markdown 코드블록(```json ... ```)으로 감싸 반환하면서, `ResumePreprocessorService`의 `objectMapper.readTree(response.trim())`가 파싱에 실패했습니다. 이 때문에 PDF 업로드는 성공했지만 `resumes.keywords`가 비어 있어 RAG 서버로 `resumeProfile`이 전달되지 않는 문제가 있었습니다.

## 동작 방식

- 이력서 전처리 LLM 응답을 파싱하기 전에 Markdown JSON 코드블록 wrapper를 제거합니다.
- 정리된 문자열을 기존 검증 로직으로 파싱/검증한 뒤 `keywords` 컬럼에 저장합니다.
- 운영에서 재현된 ` ```json ... ``` ` 응답 형태를 회귀 테스트로 추가했습니다.

## 검증

- `./gradlew test`
