### PR TITLE
[Fix] 이력서 삭제 시 그룹면접 참조 해제

### DIFF
--- a/src/main/java/com/capstone/interview/entity/InterviewParticipant.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewParticipant.java
@@ -70,6 +70,10 @@ public class InterviewParticipant {
         this.ready = true;
     }
 
+    public void clearResume() {
+        this.resume = null;
+    }
+
     public void saveTotalFeedback(String totalFeedback, String overallScore) {
         this.totalFeedback = totalFeedback;
         this.overallScore = overallScore;

--- a/src/main/java/com/capstone/interview/repository/InterviewParticipantRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewParticipantRepository.java
@@ -18,5 +18,7 @@ public interface InterviewParticipantRepository extends JpaRepository<InterviewP
 
     long countByInterviewAndReadyTrue(Interview interview);
 
+    List<InterviewParticipant> findByResumeId(Long resumeId);
+
     List<InterviewParticipant> findByMemberIdOrderByJoinedAtDesc(Long memberId);
 }

--- a/src/main/java/com/capstone/interview/service/ResumeService.java
+++ b/src/main/java/com/capstone/interview/service/ResumeService.java
@@ -4,6 +4,7 @@ import com.capstone.interview.dto.ResumeResponse;
 import com.capstone.interview.dto.ResumeUploadRequest;
 import com.capstone.interview.entity.Member;
 import com.capstone.interview.entity.Resume;
+import com.capstone.interview.repository.InterviewParticipantRepository;
 import com.capstone.interview.repository.InterviewRepository;
 import com.capstone.interview.repository.MemberRepository;
 import com.capstone.interview.repository.ResumeRepository;
@@ -30,6 +31,7 @@ public class ResumeService {
     private final ResumeRepository resumeRepository;
     private final MemberRepository memberRepository;
     private final InterviewRepository interviewRepository;
+    private final InterviewParticipantRepository interviewParticipantRepository;
 
     /**
      * PDF 이력서를 업로드하고 파싱하여 DB에 저장한다.
@@ -132,6 +134,9 @@ public class ResumeService {
         // 면접 기록에서 이력서 참조 해제
         interviewRepository.findByResumeId(resumeId)
                 .forEach(interview -> interview.clearResume());
+
+        interviewParticipantRepository.findByResumeId(resumeId)
+                .forEach(participant -> participant.clearResume());
 
         resumeRepository.delete(resume);
         log.info("[이력서 삭제] id={}, memberId={}", resumeId, member.getId());

--- a/src/test/java/com/capstone/interview/service/ResumeServiceTest.java
+++ b/src/test/java/com/capstone/interview/service/ResumeServiceTest.java
@@ -1,0 +1,91 @@
+package com.capstone.interview.service;
+
+import com.capstone.interview.entity.Interview;
+import com.capstone.interview.entity.InterviewParticipant;
+import com.capstone.interview.entity.Member;
+import com.capstone.interview.entity.ParticipantRole;
+import com.capstone.interview.entity.Resume;
+import com.capstone.interview.repository.InterviewParticipantRepository;
+import com.capstone.interview.repository.InterviewRepository;
+import com.capstone.interview.repository.MemberRepository;
+import com.capstone.interview.repository.ResumeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeServiceTest {
+
+    @Mock PdfParserService pdfParserService;
+    @Mock ResumePreprocessorService resumePreprocessorService;
+    @Mock ResumeRepository resumeRepository;
+    @Mock MemberRepository memberRepository;
+    @Mock InterviewRepository interviewRepository;
+    @Mock InterviewParticipantRepository interviewParticipantRepository;
+
+    @InjectMocks ResumeService resumeService;
+
+    @Test
+    void deleteResume_clearsInterviewAndParticipantReferencesBeforeDelete() {
+        Member member = Member.builder()
+                .loginId("user")
+                .password("password")
+                .name("User")
+                .build();
+        setId(member, 1L);
+
+        Resume resume = Resume.builder()
+                .member(member)
+                .title("resume")
+                .originalText("text")
+                .build();
+        setId(resume, 7L);
+
+        Interview interview = Interview.builder()
+                .member(member)
+                .resume(resume)
+                .category("BACKEND")
+                .sessionId("session")
+                .roomName("room")
+                .durationMinutes(15)
+                .build();
+
+        InterviewParticipant participant = InterviewParticipant.builder()
+                .interview(interview)
+                .member(member)
+                .role(ParticipantRole.HOST)
+                .resume(resume)
+                .ready(true)
+                .build();
+
+        when(memberRepository.findByLoginId("user")).thenReturn(Optional.of(member));
+        when(resumeRepository.findById(7L)).thenReturn(Optional.of(resume));
+        when(interviewRepository.findByResumeId(7L)).thenReturn(List.of(interview));
+        when(interviewParticipantRepository.findByResumeId(7L)).thenReturn(List.of(participant));
+
+        resumeService.deleteResume("user", 7L);
+
+        assertNull(interview.getResume());
+        assertNull(participant.getResume());
+        verify(resumeRepository).delete(resume);
+    }
+
+    private static void setId(Object entity, Long id) {
+        try {
+            var field = entity.getClass().getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 해결한 문제
- 이력서 삭제 시 일반 면접의 interviews.resume_id 참조는 null 처리됐지만, 그룹 면접 참가자 테이블의 interview_participants.resume_id 참조가 남아 PostgreSQL FK 제약 위반으로 삭제가 실패할 수 있었습니다.

## 변경 내용
- InterviewParticipant에 이력서 참조를 해제하는 clearResume() 메서드를 추가했습니다.
- InterviewParticipantRepository에서 esumeId 기준 참가자 레코드를 조회할 수 있게 했습니다.
- ResumeService.deleteResume()에서 이력서를 삭제하기 전에 일반 면접과 그룹 면접 참가자 양쪽의 이력서 참조를 모두 null 처리하도록 수정했습니다.
- 삭제 전에 두 FK 참조가 모두 해제되는지 검증하는 서비스 테스트를 추가했습니다.

## 동작 방식
- 사용자가 본인 이력서 삭제를 요청하면 기존처럼 소유자 검증을 먼저 수행합니다.
- 해당 이력서를 참조하는 interviews와 interview_participants 레코드의 esume_id를 트랜잭션 안에서 null 처리합니다.
- FK 참조가 해제된 뒤 esumes 레코드를 삭제하므로, 그룹 면접 이력이 남아 있어도 삭제가 정상 완료됩니다.

## 검증
- ./gradlew test 통과