### PR TITLE
[Feature] 이력서 소프트 삭제 적용

### DIFF
--- a/design.md
+++ b/design.md
@@ -362,6 +362,7 @@ erDiagram
 - `password`: 암호화된 비밀번호
 
 #### RESUMES
+- 이력서 삭제는 소프트 삭제로 처리한다. `deleted_at`이 NULL인 row만 목록/상세 조회 및 새 면접 생성에서 사용할 수 있다.
 - 회원이 등록한 이력서
 - `original_text`: PDF 파싱 또는 직접 입력한 원본 텍스트
 - `file_url`: S3에 저장된 PDF 파일 주소
@@ -418,7 +419,8 @@ CREATE TABLE resumes (
     keywords JSON,
     embedding vector(1536),
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP
 );
 
 CREATE TABLE cover_letters (
@@ -474,6 +476,7 @@ CREATE TABLE reference_data (
 
 -- 인덱스
 CREATE INDEX idx_resumes_member ON resumes(member_id);
+CREATE INDEX idx_resumes_member_deleted_at ON resumes(member_id, deleted_at);
 CREATE INDEX idx_cover_letters_member ON cover_letters(member_id);
 CREATE INDEX idx_interviews_member ON interviews(member_id);
 CREATE INDEX idx_interviews_status ON interviews(status);

--- a/scripts/add-resume-soft-delete.sql
+++ b/scripts/add-resume-soft-delete.sql
@@ -1,0 +1,4 @@
+-- Resume soft delete support (manual migration for prod ddl-auto: validate)
+
+ALTER TABLE resumes ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;
+CREATE INDEX IF NOT EXISTS idx_resumes_member_deleted_at ON resumes(member_id, deleted_at);

--- a/src/main/java/com/capstone/interview/entity/Interview.java
+++ b/src/main/java/com/capstone/interview/entity/Interview.java
@@ -117,10 +117,6 @@ public class Interview {
         this.status = InterviewStatus.FAILED;
     }
 
-    public void clearResume() {
-        this.resume = null;
-    }
-
     //EvaluationService에서 total_feedback 저장을 위해 호출
     public void saveTotalFeedback(String totalFeedback) {
         this.totalFeedback = totalFeedback;

--- a/src/main/java/com/capstone/interview/entity/InterviewParticipant.java
+++ b/src/main/java/com/capstone/interview/entity/InterviewParticipant.java
@@ -70,10 +70,6 @@ public class InterviewParticipant {
         this.ready = true;
     }
 
-    public void clearResume() {
-        this.resume = null;
-    }
-
     public void saveTotalFeedback(String totalFeedback, String overallScore) {
         this.totalFeedback = totalFeedback;
         this.overallScore = overallScore;

--- a/src/main/java/com/capstone/interview/entity/Resume.java
+++ b/src/main/java/com/capstone/interview/entity/Resume.java
@@ -43,6 +43,9 @@ public class Resume {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder
     private Resume(Member member, String title, String originalText, String fileUrl, String keywords) {
         this.member = member;
@@ -62,6 +65,10 @@ public class Resume {
 
     public void updateKeywords(String keywords) {
         this.keywords = keywords;
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
     }
 
     @PrePersist

--- a/src/main/java/com/capstone/interview/repository/InterviewParticipantRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewParticipantRepository.java
@@ -18,7 +18,5 @@ public interface InterviewParticipantRepository extends JpaRepository<InterviewP
 
     long countByInterviewAndReadyTrue(Interview interview);
 
-    List<InterviewParticipant> findByResumeId(Long resumeId);
-
     List<InterviewParticipant> findByMemberIdOrderByJoinedAtDesc(Long memberId);
 }

--- a/src/main/java/com/capstone/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewRepository.java
@@ -14,5 +14,4 @@ public interface InterviewRepository extends JpaRepository<Interview, Long> {
     //피드백 목록 조회 : 해당 회원의 COMPLETED 상태 면접만 최신순 조회
     List<Interview> findByMemberIdAndStatusOrderByCreatedAtDesc(Long memberId, InterviewStatus status);
     // 이력서 삭제 시 참조 해제용
-    List<Interview> findByResumeId(Long resumeId);
 }

--- a/src/main/java/com/capstone/interview/repository/ResumeRepository.java
+++ b/src/main/java/com/capstone/interview/repository/ResumeRepository.java
@@ -4,8 +4,11 @@ import com.capstone.interview.entity.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
 
-    List<Resume> findByMemberId(Long memberId);
+    List<Resume> findByMemberIdAndDeletedAtIsNull(Long memberId);
+
+    Optional<Resume> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/capstone/interview/service/InterviewService.java
+++ b/src/main/java/com/capstone/interview/service/InterviewService.java
@@ -495,7 +495,7 @@ public class InterviewService {
 
     private Resume resolveResume(Long resumeId) {
         if (resumeId == null) return null;
-        return resumeRepository.findById(resumeId)
+        return resumeRepository.findByIdAndDeletedAtIsNull(resumeId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이력서입니다: " + resumeId));
     }
 
@@ -577,7 +577,7 @@ public class InterviewService {
         if (request == null || request.resumeId() == null) {
             throw new IllegalArgumentException("그룹 면접 입장 시 이력서(resumeId)를 선택해야 합니다.");
         }
-        Resume resume = resumeRepository.findById(request.resumeId())
+        Resume resume = resumeRepository.findByIdAndDeletedAtIsNull(request.resumeId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이력서입니다: " + request.resumeId()));
         if (!resume.getMember().getId().equals(member.getId())) {
             throw new UnauthorizedException("본인의 이력서만 선택할 수 있습니다.");

--- a/src/main/java/com/capstone/interview/service/ResumeService.java
+++ b/src/main/java/com/capstone/interview/service/ResumeService.java
@@ -4,8 +4,6 @@ import com.capstone.interview.dto.ResumeResponse;
 import com.capstone.interview.dto.ResumeUploadRequest;
 import com.capstone.interview.entity.Member;
 import com.capstone.interview.entity.Resume;
-import com.capstone.interview.repository.InterviewParticipantRepository;
-import com.capstone.interview.repository.InterviewRepository;
 import com.capstone.interview.repository.MemberRepository;
 import com.capstone.interview.repository.ResumeRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +28,6 @@ public class ResumeService {
     private final ResumePreprocessorService resumePreprocessorService;
     private final ResumeRepository resumeRepository;
     private final MemberRepository memberRepository;
-    private final InterviewRepository interviewRepository;
-    private final InterviewParticipantRepository interviewParticipantRepository;
 
     /**
      * PDF 이력서를 업로드하고 파싱하여 DB에 저장한다.
@@ -100,7 +96,7 @@ public class ResumeService {
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
 
-        return resumeRepository.findByMemberId(member.getId()).stream()
+        return resumeRepository.findByMemberIdAndDeletedAtIsNull(member.getId()).stream()
                 .map(this::toResponse)
                 .toList();
     }
@@ -110,7 +106,7 @@ public class ResumeService {
      */
     @Transactional(readOnly = true)
     public ResumeResponse getResume(Long resumeId) {
-        Resume resume = resumeRepository.findById(resumeId)
+        Resume resume = resumeRepository.findByIdAndDeletedAtIsNull(resumeId)
                 .orElseThrow(() -> new IllegalArgumentException("이력서를 찾을 수 없습니다: " + resumeId));
         return toResponse(resume);
     }
@@ -124,21 +120,14 @@ public class ResumeService {
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
 
-        Resume resume = resumeRepository.findById(resumeId)
+        Resume resume = resumeRepository.findByIdAndDeletedAtIsNull(resumeId)
                 .orElseThrow(() -> new IllegalArgumentException("이력서를 찾을 수 없습니다: " + resumeId));
 
         if (!resume.getMember().getId().equals(member.getId())) {
             throw new IllegalArgumentException("본인의 이력서만 삭제할 수 있습니다.");
         }
 
-        // 면접 기록에서 이력서 참조 해제
-        interviewRepository.findByResumeId(resumeId)
-                .forEach(interview -> interview.clearResume());
-
-        interviewParticipantRepository.findByResumeId(resumeId)
-                .forEach(participant -> participant.clearResume());
-
-        resumeRepository.delete(resume);
+        resume.softDelete();
         log.info("[이력서 삭제] id={}, memberId={}", resumeId, member.getId());
     }
 

--- a/src/test/java/com/capstone/interview/service/ResumeServiceTest.java
+++ b/src/test/java/com/capstone/interview/service/ResumeServiceTest.java
@@ -1,12 +1,7 @@
 package com.capstone.interview.service;
 
-import com.capstone.interview.entity.Interview;
-import com.capstone.interview.entity.InterviewParticipant;
 import com.capstone.interview.entity.Member;
-import com.capstone.interview.entity.ParticipantRole;
 import com.capstone.interview.entity.Resume;
-import com.capstone.interview.repository.InterviewParticipantRepository;
-import com.capstone.interview.repository.InterviewRepository;
 import com.capstone.interview.repository.MemberRepository;
 import com.capstone.interview.repository.ResumeRepository;
 import org.junit.jupiter.api.Test;
@@ -15,12 +10,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ResumeServiceTest {
@@ -29,13 +24,11 @@ class ResumeServiceTest {
     @Mock ResumePreprocessorService resumePreprocessorService;
     @Mock ResumeRepository resumeRepository;
     @Mock MemberRepository memberRepository;
-    @Mock InterviewRepository interviewRepository;
-    @Mock InterviewParticipantRepository interviewParticipantRepository;
 
     @InjectMocks ResumeService resumeService;
 
     @Test
-    void deleteResume_clearsInterviewAndParticipantReferencesBeforeDelete() {
+    void deleteResume_marksResumeDeletedWithoutPhysicalDelete() {
         Member member = Member.builder()
                 .loginId("user")
                 .password("password")
@@ -50,33 +43,13 @@ class ResumeServiceTest {
                 .build();
         setId(resume, 7L);
 
-        Interview interview = Interview.builder()
-                .member(member)
-                .resume(resume)
-                .category("BACKEND")
-                .sessionId("session")
-                .roomName("room")
-                .durationMinutes(15)
-                .build();
-
-        InterviewParticipant participant = InterviewParticipant.builder()
-                .interview(interview)
-                .member(member)
-                .role(ParticipantRole.HOST)
-                .resume(resume)
-                .ready(true)
-                .build();
-
         when(memberRepository.findByLoginId("user")).thenReturn(Optional.of(member));
-        when(resumeRepository.findById(7L)).thenReturn(Optional.of(resume));
-        when(interviewRepository.findByResumeId(7L)).thenReturn(List.of(interview));
-        when(interviewParticipantRepository.findByResumeId(7L)).thenReturn(List.of(participant));
+        when(resumeRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(resume));
 
         resumeService.deleteResume("user", 7L);
 
-        assertNull(interview.getResume());
-        assertNull(participant.getResume());
-        verify(resumeRepository).delete(resume);
+        assertNotNull(resume.getDeletedAt());
+        verify(resumeRepository, never()).delete(resume);
     }
 
     private static void setId(Object entity, Long id) {


### PR DESCRIPTION
## 해결한 문제
- 이력서 삭제를 물리 삭제로 처리하면 해당 이력서를 참조하는 면접/참가자 데이터와 FK 관계를 계속 신경 써야 했습니다.
- 그룹면접처럼 이력서를 참조하는 테이블이 추가될 때마다 삭제 로직 누락으로 참조 무결성 문제가 다시 생길 수 있었습니다.

## 변경 내용
- esumes에 deleted_at 컬럼을 추가해 이력서를 소프트 삭제하도록 변경했습니다.
- 이력서 삭제 API는 더 이상 esumes row를 삭제하지 않고 deleted_at만 기록합니다.
- 이력서 목록/상세 조회는 deleted_at IS NULL인 이력서만 반환하도록 변경했습니다.
- 일반/그룹 면접 생성 시 삭제된 이력서는 선택할 수 없도록 조회 조건을 변경했습니다.
- 물리 삭제 전제로 추가됐던 이력서 참조 해제 로직과 관련 dead code를 제거했습니다.
- 운영 DB용 수동 마이그레이션 스크립트 scripts/add-resume-soft-delete.sql을 추가했습니다.

## 동작 방식
- 사용자가 이력서를 삭제하면 실제 DB row는 유지되고 deleted_at에 삭제 시간이 저장됩니다.
- 사용자 화면의 이력서 목록과 상세 조회에서는 삭제된 이력서가 보이지 않습니다.
- 새 면접을 만들거나 그룹면접에 입장할 때 삭제된 이력서 ID를 보내면 존재하지 않는 이력서처럼 처리됩니다.
- 기존 면접 기록은 이력서 row가 유지되므로 FK 제약 위반 없이 보존됩니다.

## 운영 반영 참고
- prod는 ddl-auto: validate라서 배포 전 scripts/add-resume-soft-delete.sql 실행이 필요합니다.

## 검증
- ./gradlew test 통과