### PR TITLE
[Fix] 피드백 생성 대기시간 개선

### DIFF
--- a/src/main/java/com/capstone/interview/repository/InterviewQnaRepository.java
+++ b/src/main/java/com/capstone/interview/repository/InterviewQnaRepository.java
@@ -3,6 +3,9 @@ package com.capstone.interview.repository;
 import com.capstone.interview.entity.Interview;
 import com.capstone.interview.entity.InterviewQna;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -15,6 +18,18 @@ public interface InterviewQnaRepository extends JpaRepository<InterviewQna, Long
 
     Optional<InterviewQna> findByInterviewAndSequenceNumber(Interview interview, Integer sequenceNumber);
     int countByInterview(Interview interview);
+
+    @Query("""
+            SELECT COUNT(q)
+            FROM InterviewQna q
+            WHERE q.interview.sessionId = :sessionId
+              AND (
+                    q.questionContent IS NULL
+                    OR q.questionContent = ''
+                    OR q.answerSummary IS NULL
+              )
+            """)
+    long countPendingAgentSaves(@Param("sessionId") String sessionId);
     // 면접 기록 삭제 시 관련 QnA 일괄 삭제 (셀프 참조 FK 고려하여 네이티브 쿼리 사용)
     @org.springframework.data.jpa.repository.Modifying
     @org.springframework.data.jpa.repository.Query("DELETE FROM InterviewQna q WHERE q.interview = :interview")

--- a/src/main/java/com/capstone/interview/service/EvaluationService.java
+++ b/src/main/java/com/capstone/interview/service/EvaluationService.java
@@ -27,6 +27,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EvaluationService {
 
+    private static final long AGENT_SAVE_WAIT_TIMEOUT_MS = 5_000L;
+    private static final long AGENT_SAVE_POLL_INTERVAL_MS = 250L;
+
     private static final String TURN_EVALUATION_SYSTEM_PROMPT = """
             당신은 신입/주니어 개발자 기술 면접 답변을 평가하는 전문 면접관입니다.
 
@@ -158,8 +161,6 @@ public class EvaluationService {
     @Async
     @Transactional
     public void evaluate(String sessionId) {
-        waitForLastAgentSave();
-
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
 
@@ -172,6 +173,13 @@ public class EvaluationService {
             evaluateAllParticipants(sessionId);
             return;
         }
+
+        if (!waitForLastAgentSave(sessionId)) {
+            return;
+        }
+
+        interview = interviewRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
 
         if (interview.getTotalFeedback() != null) {
             log.info("[evaluation skipped] already completed sessionId={}", sessionId);
@@ -205,7 +213,9 @@ public class EvaluationService {
     @Async
     @Transactional
     public void evaluateAllParticipants(String sessionId) {
-        waitForLastAgentSave();
+        if (!waitForLastAgentSave(sessionId)) {
+            return;
+        }
 
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
@@ -231,7 +241,9 @@ public class EvaluationService {
     @Async
     @Transactional
     public void evaluateParticipant(String sessionId, Long memberId) {
-        waitForLastAgentSave();
+        if (!waitForLastAgentSave(sessionId)) {
+            return;
+        }
 
         Interview interview = interviewRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("면접 세션을 찾을 수 없습니다: " + sessionId));
@@ -465,9 +477,27 @@ public class EvaluationService {
         return response;
     }
 
-    private void waitForLastAgentSave() {
+    private boolean waitForLastAgentSave(String sessionId) {
+        long deadline = System.nanoTime() + AGENT_SAVE_WAIT_TIMEOUT_MS * 1_000_000L;
+        long pending = interviewQnaRepository.countPendingAgentSaves(sessionId);
+
+        while (pending > 0 && System.nanoTime() < deadline) {
+            sleep(AGENT_SAVE_POLL_INTERVAL_MS);
+            pending = interviewQnaRepository.countPendingAgentSaves(sessionId);
+        }
+
+        if (pending > 0) {
+            log.warn("[evaluation wait timeout] sessionId={}, pendingAgentSaves={}", sessionId, pending);
+            return false;
+        }
+
+        log.info("[evaluation wait completed] sessionId={}", sessionId);
+        return true;
+    }
+
+    private void sleep(long millis) {
         try {
-            Thread.sleep(5_000);
+            Thread.sleep(millis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }


### PR DESCRIPTION
## 변경 사항
- 피드백 평가 시작 전 5초 고정 대기를 제거하고, 미저장 QnA가 있을 때만 최대 5초까지 250ms 간격으로 확인하도록 변경했습니다.
- 마지막 QnA 저장이 끝나지 않으면 종합 피드백 생성을 보류해 모든 개별 피드백이 종합 피드백에 반영되는 조건을 유지했습니다.
- 그룹/개별 평가 경로도 동일한 대기 로직을 사용하도록 정리했습니다.

## 해결된 문제
면접 종료 후 피드백 생성이 항상 최소 5초 늦게 시작되던 문제가 있었습니다. 이제 Agent가 마지막 QnA를 빠르게 저장하면 즉시 평가를 시작하고, 저장이 늦는 경우에는 불완전한 종합 피드백을 만들지 않습니다.

## 검증
- .\gradlew test